### PR TITLE
handlers.go: allow overriding WireGuard endpoint

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -385,7 +385,6 @@ func profileAddHandler(w *Web) {
 	if cidr := getEnv("SUBSPACE_IPV4_CIDR", "nil"); cidr != "nil" {
 		ipv4Cidr = cidr
 	}
-
 	ipv6Pref := "fd00::10:97:"
 	if pref := getEnv("SUBSPACE_IPV6_PREF", "nil"); pref != "nil" {
 		ipv6Pref = pref
@@ -401,6 +400,10 @@ func profileAddHandler(w *Web) {
 	listenport := "51820"
 	if port := getEnv("SUBSPACE_LISTENPORT", "nil"); port != "nil" {
 		listenport = port
+	}
+	endpointHost := httpHost
+	if eh := getEnv("SUBSPACE_ENDPOINT_HOST", "nil"); eh != "nil" {
+		endpointHost = eh
 	}
 
 	script := `
@@ -424,24 +427,24 @@ Address = {{$.IPv4Pref}}{{$.Profile.Number}}/{{$.IPv4Cidr}},{{$.IPv6Pref}}{{$.Pr
 
 [Peer]
 PublicKey = $(cat server.public)
-Endpoint = {{$.Domain}}:{{$.Listenport}}
+Endpoint = {{$.EndpointHost}}:{{$.Listenport}}
 AllowedIPs = 0.0.0.0/0, ::/0
 WGCLIENT
 `
 	_, err = bash(script, struct {
-		Profile    Profile
-		Domain     string
-		Datadir    string
-		IPv4Gw     string
-		IPv6Gw     string
-		IPv4Pref   string
-		IPv6Pref   string
-		IPv4Cidr   string
-		IPv6Cidr   string
-		Listenport string
+		Profile      Profile
+		EndpointHost string
+		Datadir      string
+		IPv4Gw       string
+		IPv6Gw       string
+		IPv4Pref     string
+		IPv6Pref     string
+		IPv4Cidr     string
+		IPv6Cidr     string
+		Listenport   string
 	}{
 		profile,
-		httpHost,
+		endpointHost,
 		datadir,
 		ipv4Gw,
 		ipv6Gw,

--- a/handlers.go
+++ b/handlers.go
@@ -436,8 +436,8 @@ AllowedIPs = {{$.allowedips}}
 WGCLIENT
 `
 	_, err = bash(script, struct {
-    Profile      Profile
-    EndpointHost string
+                Profile      Profile
+                EndpointHost string
 		Datadir      string
 		IPv4Gw       string
 		IPv6Gw       string


### PR DESCRIPTION
When running on platforms like Kubernetes, the domain name used for
handling HTTP may not be the name of the host running WireGuard. For
example, HTTP ingress is load balanced across all Kubernetes nodes in
the cluster but WireGuard is only run on a single node in the cluster.
This commit enables setting the WireGuard endpoint independently of the
HTTP hostname. If `SUBSPACE_ENDPOINT_HOST` is unset, it defaults to the
value of `SUBSPACE_HTTP_HOST` so that the old behavior is kept.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>