### PR TITLE
main.go: fix URL for insecure SAML

### DIFF
--- a/main.go
+++ b/main.go
@@ -372,6 +372,10 @@ func configureSAML() error {
 		Path:   "/",
 	}
 
+	if httpInsecure {
+		rootURL.Scheme = "http"
+	}
+
 	newsp, err := samlsp.New(samlsp.Options{
 		URL:               rootURL,
 		Key:               keyPair.PrivateKey.(*rsa.PrivateKey),


### PR DESCRIPTION
If the server is running in insecure mode, then the SAML callback URL
needs to be HTTP rather than HTTPS.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>