### PR TITLE
Adding link to JumpCloud for the settings page

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -44,7 +44,7 @@
                     <a class="item" target="_blank" href="https://support.google.com/a/answer/6087519?hl=en"><i class="right triangle icon"></i>Instructions for G Suite users</a>
                     <a class="item" target="_blank" href="https://developer.okta.com/standards/SAML/setting_up_a_saml_application_in_okta/"><i class="right triangle icon"></i>Instructions for Okta users</a>
                     <a class="item" target="_blank" href="https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-single-sign-on-non-gallery-applications"><i class="right triangle icon"></i>Instructions for Azure AD users</a>
-                    
+                    <a class="item" target="_blank" href="https://support.jumpcloud.com/support/s/article/getting-started-applications-saml-sso2"><i class="right triangle icon"></i>Instructions for JumpCloud users</a>
                 </div>
             </div>
             <div class="ui hidden divider"></div>


### PR DESCRIPTION
## Description
resolves: #24 

### Reason for the change
Want to make it easier for others to configure this application with JumpCloud

### Changes

* Added a link to the documentation for JumpCloud

### Additional comments

Ensure to enable to application for users on the JumpCloud side and the
following settings:

- `Declare Redirect Endpoint` - toggle on
- `IdP-Initiated URL` - set to "https://YOUR_SUBSPACE_DOMAIN/sso"
- `SAMLSubject NameID` - email
- `SAMLSubject NameID Format` - urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress