### PR TITLE
Move Running docker to use Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV GODEBUG="netdns=go http2server=0"
 
 RUN make BUILD_VERSION=${BUILD_VERSION}
 
-FROM phusion/baseimage:0.11
+FROM alpine:3.11.6
 LABEL maintainer="github.com/subspacecommunity/subspace"
 
 COPY --from=build  /src/subspace-linux-amd64 /usr/bin/subspace
@@ -30,9 +30,12 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN chmod +x /usr/bin/subspace /usr/local/bin/entrypoint.sh
 
-RUN apt-get update \
-    && apt-get install -y iproute2 iptables dnsmasq socat
+RUN apk add --no-cache \
+    iproute2 \
+    iptables \ 
+    dnsmasq \
+    socat 
 
-ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+ENTRYPOINT [ "sh", "/usr/local/bin/entrypoint.sh" ]
 
 CMD [ "/sbin/my_init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ RUN apk add --no-cache \
     dnsmasq \
     socat 
 
-ENTRYPOINT [ "sh", "/usr/local/bin/entrypoint.sh" ]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh" ]
 
 CMD [ "/sbin/my_init" ]

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ all: subspace-linux-amd64
 BUILD_VERSION?=unknown
 
 subspace-linux-amd64:
-	go get -u github.com/jteeuwen/go-bindata/... \
+	go get -u github.com/kevinburke/go-bindata/...\
 	&& go mod download \
-	&& go run github.com/jteeuwen/go-bindata/go-bindata --pkg main static/... templates/... email/.. \
+	&& go run github.com/kevinburke/go-bindata/go-bindata --pkg main static/... templates/... email/.. \
 	&& go generate \
 	&& go fmt \
 	&& go vet --all

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
The following change moves us from `phusion/baseimage` a minimal docker container which was last updated Aug 2018 to a more up to date alpine linux version. 

I have also changed the version of go-bindata to https://github.com/kevinburke/go-bindata as this is a supported and maintained version compared to the archived fork we were previously using. 

From limited testing these works without issue and a clean build is sub 15 seconds. 
