### PR TITLE
Replace perl command with awk

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -599,7 +599,7 @@ func deleteProfile(profile Profile) error {
 	script := `
 # WireGuard
 cd {{$.Datadir}}/wireguard
-peerid=$(cat peers/{{$.Profile.ID}}.conf | perl -ne 'print $1 if /PublicKey\s*=\s*(.*)/')
+peerid=$(cat peers/{{$.Profile.ID}}.conf | awk '/PublicKey/ { printf("%s", $3) }' )
 wg set wg0 peer $peerid remove
 rm peers/{{$.Profile.ID}}.conf
 rm clients/{{$.Profile.ID}}.conf


### PR DESCRIPTION
This removes perl dependency with awk, awk is installed by default.

to:
cc: @subspacecommunity/subspace-maintainers
related to: #75
resolves:

## Background

Perl is used only in one oneliner, we can replace it with awk wich is installed by default.

### Changes

Replace perl oneliner with awk oneliner.


## Testing

Current master seems to be broken, I tested this with branch #75 with perl removed from Dockerfile. Delete user was working as expected.

