### PR TITLE
Set the SAML name ID format to email address

### DIFF
--- a/main.go
+++ b/main.go
@@ -385,6 +385,9 @@ func configureSAML() error {
 		samlSP = nil
 		return fmt.Errorf("failed to configure SAML: %s", err)
 	}
+	
+	newsp.ServiceProvider.AuthnNameIDFormat = saml.EmailAddressNameIDFormat
+	
 	samlSP = newsp
 	logger.Infof("successfully configured SAML")
 	return nil


### PR DESCRIPTION
cc: @subspacecommunity/subspace-maintainers
resolves: #94 

## Background

The `saml` library requires, [by default][0] a transient (`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`) name-id.

The transient name id is temporary per session, making impossible to create users using it, since it would be different
for every request. While some Identity Providers (e.g., JumpCloud, Google) allow to override such request to return
an email address, Azure and Office 365 will honor the request:

> If the SAML request contains the element NameIDPolicy with a specific format, then Azure AD will honor the format in the request.
> If the SAML request doesn't contain an element for NameIDPolicy, then Azure AD will issue the NameID with the format you specify. If no format is specified Azure AD will use the default source format associated with the claim source selected.

Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-saml-claims-customization#editing-nameid

Thus, subspace cannot work with Azure and Office 365.

### Changes

With this change, subspace will explicitly request an email (`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`) as nameid, to be able to properly manage users also with Azure and Office 365



[0]: https://github.com/crewjam/saml/blob/17489b9c3af5c6ca7224d71cf3469bd637410111/service_provider.go#L904
