### PR TITLE
source envvars before service run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -175,6 +175,7 @@ if ! test -d /etc/service/subspace; then
   mkdir /etc/service/subspace
   cat <<RUNIT >/etc/service/subspace/run
 #!/bin/sh
+source /etc/envvars
 exec /usr/bin/subspace \
     "--http-host=${SUBSPACE_HTTP_HOST}" \
     "--http-addr=${SUBSPACE_HTTP_ADDR}" \


### PR DESCRIPTION
to:
cc: @subspacecommunity/subspace-maintainers
related to:
resolves: #90 #97

## Background

Bug reports were raised and this is how i can fix it. There MIGHT be a better solution than this in terms of using `KEY=VALUE` as part of the below. But i personally feely like this approach is better as ALL environment variables are only relevant to `subspace`
https://github.com/subspacecommunity/subspace/blob/15ff6dbc430d3f28f61b44d237604783a5f4865d/bin/my_init#L30

### Changes

* source the `/etc/envvars` file before calling `subspace`

## Testing

- Ran locally by adding `env > /data/wireguard/environment` to `entrypoint.sh` line 179 and observed the expected envvars as passed in from `docker-compose` 


