### PR TITLE
[Fix #127] Data dir permission is too wide

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,6 +113,8 @@ fi
 #
 # WireGuard (${SUBSPACE_IPV4_POOL})
 #
+umask_val=$(umask)
+umask 0077
 if ! test -d /data/wireguard; then
   mkdir /data/wireguard
   cd /data/wireguard
@@ -133,6 +135,8 @@ ListenPort = ${SUBSPACE_LISTENPORT}
 
 WGSERVER
 cat /data/wireguard/peers/*.conf >>/data/wireguard/server.conf
+umask ${umask_val}
+[ -f /data/config.json ] && chmod 600 /data/config.json # Special handling of file not created by start-up script
 
 if ip link show wg0 2>/dev/null; then
   ip link del wg0


### PR DESCRIPTION
to:
cc: @subspacecommunity/subspace-maintainers
related to:
resolves: #127 

## Background

Data directory default permission is too wide that allows anyone from the system to read the configuration files

### Changes

* Summary of changes
- Changed umask of the user during the section creating configuration files
- Added special handling for config.json to update the permission upon next start-up


## Testing

Using the updated entrypoint.sh

[root@localhost subspace]# rm -rf data
[root@localhost subspace]# docker-compose up -d
Creating subspace ... done
[root@localhost subspace]# ls -alh data
total 8.0K
drwxr-xr-x. 3 root root   42 Jul 26 02:29 .
drwxr-xr-x. 8 root root  156 Jul 26 02:28 ..
-rw-r--r--. 1 root root 4.3K Jul 26 02:29 config.json  <- It was generated at later stage by the subspace process
drwx------. 4 root root   96 Jul 26 02:28 wireguard   <- Permission tightened
[root@localhost subspace]# docker-compose restart
Restarting subspace ... done
[root@localhost subspace]# ls -alh data
total 8.0K
drwxr-xr-x. 3 root root   42 Jul 26 02:29 .
drwxr-xr-x. 8 root root  156 Jul 26 02:28 ..
-rw-------. 1 root root 4.3K Jul 26 02:29 config.json <- Permission tightened upon 2nd run
drwx------. 4 root root   96 Jul 26 02:28 wireguard



