### PR TITLE
Redirect to /user/edit path only needed if we are admin.

### DIFF
--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -501,7 +501,7 @@ func profileDeleteHandler(w *Web) {
 		w.Redirect("/profile/delete?error=deleteprofile")
 		return
 	}
-	if profile.UserID != "" {
+	if w.Admin {
 		w.Redirect("/user/edit/%s?success=deleteprofile", profile.UserID)
 		return
 	}


### PR DESCRIPTION
to:
cc: @subspacecommunity/subspace-maintainers
related to:
resolves: #134 

## Background

While evaluating an instance of Subspace running in its docker container (subspacecommunity/subspace:latest), I noticed that when I login as a normal user (via SAML), deletion of device profiles works but I get an error page after I click the "Delete device?" popup.

Running in debug mode showed a "permission denied" on the /user/edit path. When looking at a clone of the repo, I realized that the profileDeleteHandler is trying to redirect back to the /user/edit path even when I'm not logged in as an admin. Normal behavior should be to only redirect to /user/edit if I'm admin and otherwise move on (the redirect to the normal "success" path is immediately below this and it was obviously never being reached).

### Changes

* HTTP redirect after successful device profile deletion only goes to /user/edit if the current user is an admin. Otherwise, continues and is redirected to the normal URL.


## Testing

This was tested on a VM running a docker image built from these changes. Profiles were added to a normal account and then deleted using both an admin account and that regular account. Both ways now work without error.