### PR TITLE
FIx typo in resolved.conf file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ apt-get install -y wireguard
 apt-get remove -y dnsmasq
 
 # Disable systemd-resolved listener if it blocks port 53.
-echo "DNSStubListener=no" >> /etc/systemd/resolvd.conf
+echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
 systemctl restart systemd-resolved
 
 # Set Cloudfare DNS server.


### PR DESCRIPTION
to:
cc: @subspacecommunity/subspace-maintainers
related to:
resolves:

## Background

Typo in the readme to disable resolved dns

### Changes

* Summary of changes
* ...


## Testing

Steps for how this change was tested and verified


