### PR TITLE
readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ $ subspace --http-host subspace.example.com
 The container expects WireGuard to be installed on the host. The official image is `subspacecommunity/subspace`.
 
 ```bash
-add-apt-repository -y ppa:wireguard/wireguard
 apt-get update
 apt-get install -y wireguard
 


### PR DESCRIPTION
https://launchpad.net/~wireguard  was formerly responsible for producing the PPA for WireGuard on Ubuntu. That functionality has now been folded into Ubuntus ≥ 16.04 itself, so the old PPA has been removed