### PR TITLE
Allow extending dnsmasq by providing custom configuration.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -103,6 +103,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "gianlazz",
+      "name": "Gian Lazzarini",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1166579?v=4",
+      "profile": "https://github.com/gianlazz",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Subspace - A simple WireGuard VPN server GUI
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![](https://images.microbadger.com/badges/image/subspacecommunity/subspace.svg)](https://microbadger.com/images/subspacecommunity/subspace "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/subspacecommunity/subspace.svg)](https://microbadger.com/images/subspacecommunity/subspace "Get your own version badge on microbadger.com")
@@ -255,6 +255,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/clementperon"><img src="https://avatars.githubusercontent.com/u/1859302?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Clément Péron</b></sub></a><br /><a href="https://github.com/subspacecommunity/subspace/commits?author=clementperon" title="Documentation">📖</a></td>
     <td align="center"><a href="http://blog.selvakn.in"><img src="https://avatars.githubusercontent.com/u/30524?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Selva</b></sub></a><br /><a href="https://github.com/subspacecommunity/subspace/commits?author=selvakn" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/syphernl"><img src="https://avatars.githubusercontent.com/u/639906?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Frank</b></sub></a><br /><a href="https://github.com/subspacecommunity/subspace/commits?author=syphernl" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/gianlazz"><img src="https://avatars.githubusercontent.com/u/1166579?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gian Lazzarini</b></sub></a><br /><a href="https://github.com/subspacecommunity/subspace/commits?author=gianlazz" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -164,18 +164,20 @@ docker create \
     --network host \
     --cap-add NET_ADMIN \
     --volume /data:/data \
+    # Optional directory for mounting dnsmasq configurations
+    --volume /etc/dnsmasq.d:/etc/dnsmasq.d \
     --env SUBSPACE_HTTP_HOST="subspace.example.com" \
-	# Optional variable to change upstream DNS provider
+    # Optional variable to change upstream DNS provider
     --env SUBSPACE_NAMESERVERS="1.1.1.1,8.8.8.8" \
-	# Optional variable to change WireGuard Listenport
+    # Optional variable to change WireGuard Listenport
     --env SUBSPACE_LISTENPORT="51820" \
     # Optional variables to change IPv4/v6 prefixes
     --env SUBSPACE_IPV4_POOL="10.99.97.0/24" \
     --env SUBSPACE_IPV6_POOL="fd00::10:97:0/64" \
-	# Optional variables to change IPv4/v6 Gateway
+    # Optional variables to change IPv4/v6 Gateway
     --env SUBSPACE_IPV4_GW="10.99.97.1" \
     --env SUBSPACE_IPV6_GW="fd00::10:97:1" \
-	# Optional variable to enable or disable IPv6 NAT
+    # Optional variable to enable or disable IPv6 NAT
     --env SUBSPACE_IPV6_NAT_ENABLED=1 \
     subspacecommunity/subspace:latest
 
@@ -197,6 +199,7 @@ services:
    container_name: subspace
    volumes:
     - /opt/docker/subspace:/data
+    - /opt/docker/dnsmasq:/etc/dnsmasq.d
    restart: always
    environment:
     - SUBSPACE_HTTP_HOST=subspace.example.org

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,6 +158,9 @@ if ! test -d /etc/service/dnsmasq; then
 
     # Never forward addresses in the non-routed address spaces.
     bogus-priv
+    
+    # Allow extending dnsmasq by providing custom configurations.
+    conf-dir=/etc/dnsmasq.d
 DNSMASQ
 
   mkdir -p /etc/service/dnsmasq


### PR DESCRIPTION
cc: @subspacecommunity/subspace-maintainers

## Background

Reason for the change

dnsmasq can be used for accomplish a wide variety of tasks. This change lets us mount dnsmasq configurations inside the subspace container to provide additional configuration to dnsmasq.

For example you could override hostnames by creating the following config file and then mounting it inside subspace.

**/opt/docker/dnsmasq/01-static-dns.conf** 
```
address=/a.example.com/172.16.0.10
address=/b.example.com/172.16.0.11
```

**docker-compose.yml**
```
   volumes:
   - /opt/docker/subspace:/data
   - /opt/docker/dnsmasq:/etc/dnsmasq.d
```

### Changes

* Include `/etc/dnsmasq.d` in dnsmasq config at `/etc/dnsmasq.conf`

## Testing

The container works as expected with additional dnsmasq configuration mounted and without.
