### PR TITLE
Docker: bump to golang 1.16-alpine for build and alpine 3.13.4 for run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.14 as build
+FROM golang:1.16-alpine as build
 
-RUN apt-get update \
-    && apt-get install -y git make \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    git \
+    make
 
 WORKDIR /src
 
@@ -18,7 +18,7 @@ ENV GODEBUG="netdns=go http2server=0"
 
 RUN make build BUILD_VERSION=${BUILD_VERSION}
 
-FROM alpine:3.11.6
+FROM alpine:3.13.4
 LABEL maintainer="github.com/subspacecommunity/subspace"
 
 COPY --from=build  /src/subspace /usr/bin/subspace

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ help:  ## Display this help message and exit
 
 build: clean ## Build the binary
 	@echo "Creating bindata.go..."
+	@go get -u github.com/kevinburke/go-bindata/go-bindata
 	@go run github.com/kevinburke/go-bindata/go-bindata -o cmd/subspace/bindata.go --prefix "web/" --pkg main web/...
 	@echo "+++ bindata.go created"
 


### PR DESCRIPTION
Bump to latest golang and alpine docker.