### PR TITLE
Fix git ignores entire cmd/subspace folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 vendor/
 
 # Subspace
-subspace
+/subspace
 bindata.go
 
 # User Specific


### PR DESCRIPTION
We only need to ignore subspace bin produced by build process

to:
cc: @subspacecommunity/subspace-maintainers
related to:
resolves:

## Background

Reason for the change

### Changes

* Summary of changes
* ...


## Testing

Steps for how this change was tested and verified


