### PR TITLE
FIX: /data creation in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,7 +116,7 @@ fi
 # WireGuard (${SUBSPACE_IPV4_POOL})
 #
 if ! test -d /data/wireguard; then
-  mkdir /data/wireguard
+  mkdir -p /data/wireguard
   cd /data/wireguard
 
   mkdir clients


### PR DESCRIPTION
to: @subspacecommunity/subspace-maintainers
cc: @subspacecommunity/subspace-maintainers
related to:
resolves:

Error if /data volume is not created via docker, the entrypoint tries to create /data/wireguard and fails.

## Background

This would allow to launch the docker image without persistence

### Changes

The entrypoint.sh file, add a -p to the mkdir


## Testing

Launch the image without creating a volume, it would fail before.


