### PR TITLE
Patch: Fix URL path, WG subnet and initsetup route logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ subspace --http-host subspace.example.com
 |      flag       | default | description                                                                                                               |
 | :-------------: | :-----: | :------------------------------------------------------------------------------------------------------------------------ |
 |   `http-host`   |         | REQUIRED: The host to listen on and set cookies for                                                                       |
-|   `backlink`    |   ``   | OPTIONAL: The subdirectory that runs `subspace` |
+|   `subdir`    |   ``   | OPTIONAL: The subdirectory that runs `subspace` |
 |    `datadir`    | `/data` | OPTIONAL: The directory to store data such as the WireGuard configuration files                                           |
 |     `debug`     |         | OPTIONAL: Place subspace into debug mode for verbose log output                                                           |
 |   `http-addr`   |  `:80`  | OPTIONAL: HTTP listen address                                                                                             |
@@ -125,7 +125,7 @@ $ subspace --http-host subspace.example.com
 | `SUBSPACE_IPV4_NAT_ENABLED` | `true`              | Whether to enable NAT routing for IPv4                                                                                                               |
 | `SUBSPACE_IPV6_NAT_ENABLED` | `true`              | Whether to enable NAT routing for IPv6                                                                                                               |
 | `SUBSPACE_THEME`            | `green`             | The theme to use, please refer to [semantic-ui](https://semantic-ui.com/usage/theming.html) for accepted colors                                      |
-| `SUBSPACE_BACKLINK`         | `/`                 | The subdirectory that runs `subspace` |
+| `SUBSPACE_URL_SUBDIRECTORY`         | `/`                 | The subdirectory that runs `subspace` |
 | `SUBSPACE_DISABLE_DNS`      | `false`             | Whether to disable DNS so the client uses their own configured DNS server(s). Consider disabling DNS server, if supporting international VPN clients |
 
 ### Run as a Docker container

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ subspace --http-host subspace.example.com
 | `SUBSPACE_IPV4_NAT_ENABLED` | `true`              | Whether to enable NAT routing for IPv4                                                                                                               |
 | `SUBSPACE_IPV6_NAT_ENABLED` | `true`              | Whether to enable NAT routing for IPv6                                                                                                               |
 | `SUBSPACE_THEME`            | `green`             | The theme to use, please refer to [semantic-ui](https://semantic-ui.com/usage/theming.html) for accepted colors                                      |
-| `SUBSPACE_URL_SUBDIRECTORY`         | `/`                 | The subdirectory that runs `subspace` |
+| `SUBSPACE_URL_SUBDIRECTORY`         | ``                 | The subdirectory that runs `subspace` |
 | `SUBSPACE_DISABLE_DNS`      | `false`             | Whether to disable DNS so the client uses their own configured DNS server(s). Consider disabling DNS server, if supporting international VPN clients |
 
 ### Run as a Docker container

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ subspace --http-host subspace.example.com
 |      flag       | default | description                                                                                                               |
 | :-------------: | :-----: | :------------------------------------------------------------------------------------------------------------------------ |
 |   `http-host`   |         | REQUIRED: The host to listen on and set cookies for                                                                       |
-|   `backlink`    |   ``   | OPTIONAL: The page to set the home button to                                                                              |
+|   `backlink`    |   ``   | OPTIONAL: The subdirectory that runs `subspace` |
 |    `datadir`    | `/data` | OPTIONAL: The directory to store data such as the WireGuard configuration files                                           |
 |     `debug`     |         | OPTIONAL: Place subspace into debug mode for verbose log output                                                           |
 |   `http-addr`   |  `:80`  | OPTIONAL: HTTP listen address                                                                                             |
@@ -125,7 +125,7 @@ $ subspace --http-host subspace.example.com
 | `SUBSPACE_IPV4_NAT_ENABLED` | `true`              | Whether to enable NAT routing for IPv4                                                                                                               |
 | `SUBSPACE_IPV6_NAT_ENABLED` | `true`              | Whether to enable NAT routing for IPv6                                                                                                               |
 | `SUBSPACE_THEME`            | `green`             | The theme to use, please refer to [semantic-ui](https://semantic-ui.com/usage/theming.html) for accepted colors                                      |
-| `SUBSPACE_BACKLINK`         | `/`                 | The page to set the home button to                                                                                                                   |
+| `SUBSPACE_BACKLINK`         | `/`                 | The subdirectory that runs `subspace` |
 | `SUBSPACE_DISABLE_DNS`      | `false`             | Whether to disable DNS so the client uses their own configured DNS server(s). Consider disabling DNS server, if supporting international VPN clients |
 
 ### Run as a Docker container

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ subspace --http-host subspace.example.com
 |      flag       | default | description                                                                                                               |
 | :-------------: | :-----: | :------------------------------------------------------------------------------------------------------------------------ |
 |   `http-host`   |         | REQUIRED: The host to listen on and set cookies for                                                                       |
-|   `backlink`    |   `/`   | OPTIONAL: The page to set the home button to                                                                              |
+|   `backlink`    |   ``   | OPTIONAL: The page to set the home button to                                                                              |
 |    `datadir`    | `/data` | OPTIONAL: The directory to store data such as the WireGuard configuration files                                           |
 |     `debug`     |         | OPTIONAL: Place subspace into debug mode for verbose log output                                                           |
 |   `http-addr`   |  `:80`  | OPTIONAL: HTTP listen address                                                                                             |

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -176,7 +176,7 @@ func forgotHandler(w *Web) {
 		return
 	}
 	if email != "" && secret != "" && !validPassword.MatchString(password) {
-		w.Redirect(backlink+"/forgot?error=invalid&email=%s&secret=%s", email, secret)
+		w.Redirect(backlink + "/forgot?error=invalid&email=%s&secret=%s", email, secret)
 		return
 	}
 
@@ -322,7 +322,7 @@ func userEditHandler(w *Web) {
 	}
 
 	if w.User.ID == user.ID {
-		w.Redirect(backlink+"/user/edit/%s", user.ID)
+		w.Redirect(backlink + "/user/edit/%s", user.ID)
 		return
 	}
 
@@ -333,7 +333,7 @@ func userEditHandler(w *Web) {
 		return nil
 	})
 
-	w.Redirect(backlink+"/user/edit/%s?success=edituser", user.ID)
+	w.Redirect(backlink + "/user/edit/%s?success=edituser", user.ID)
 }
 
 func userDeleteHandler(w *Web) {
@@ -351,7 +351,7 @@ func userDeleteHandler(w *Web) {
 		return
 	}
 	if w.User.ID == user.ID {
-		w.Redirect(backlink+"/user/edit/%s?error=deleteuser", user.ID)
+		w.Redirect(backlink + "/user/edit/%s?error=deleteuser", user.ID)
 		return
 	}
 
@@ -531,7 +531,7 @@ WGCLIENT
 		return
 	}
 
-	w.Redirect(backlink+"/profile/connect/%s?success=addprofile", profile.ID)
+	w.Redirect(backlink + "/profile/connect/%s?success=addprofile", profile.ID)
 }
 
 func profileConnectHandler(w *Web) {
@@ -574,7 +574,7 @@ func profileDeleteHandler(w *Web) {
 		return
 	}
 	if len(profile.UserID) > 0 && w.Admin {
-		w.Redirect(backlink+"/user/edit/%s?success=deleteprofile", profile.UserID)
+		w.Redirect(backlink + "/user/edit/%s?success=deleteprofile", profile.UserID)
 		return
 	}
 	w.Redirect(backlink + "?success=deleteprofile")

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -573,7 +573,7 @@ func profileDeleteHandler(w *Web) {
 		w.Redirect(backlink + "/profile/delete?error=deleteprofile")
 		return
 	}
-	if w.Admin {
+	if len(profile.UserID) > 0 && w.Admin {
 		w.Redirect(backlink + "/user/edit/%s?success=deleteprofile", profile.UserID)
 		return
 	}

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -36,7 +36,7 @@ var (
 func ssoHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	session, err := samlSP.Session.GetSession(r)
 	if session != nil {
-		http.Redirect(w, r, backlink + "/", http.StatusFound)
+		http.Redirect(w, r, backlink, http.StatusFound)
 		return
 	}
 	if err == samlsp.ErrNoSession {
@@ -227,7 +227,7 @@ func forgotHandler(w *Web) {
 		Error(w.w, err)
 		return
 	}
-	w.Redirect(backlink + "/")
+	w.Redirect(backlink)
 }
 
 func signoutHandler(w *Web) {
@@ -266,7 +266,7 @@ func signinHandler(w *Web) {
 		return
 	}
 
-	w.Redirect(backlink + "/")
+	w.Redirect(backlink)
 }
 
 func totpQRHandler(w *Web) {
@@ -581,6 +581,10 @@ func profileDeleteHandler(w *Web) {
 }
 
 func indexHandler(w *Web) {
+	w.Redirect(backlink)
+}
+
+func rootIndexHandler(w *Web) {
 	if w.User.ID != "" {
 		w.TargetProfiles = config.ListProfilesByUser(w.User.ID)
 	}

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -36,7 +36,7 @@ func getEnv(key, fallback string) string {
 func ssoHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	session, err := samlSP.Session.GetSession(r)
 	if session != nil {
-		http.Redirect(w, r, backlink, http.StatusFound)
+		http.Redirect(w, r, subdir, http.StatusFound)
 		return
 	}
 	if err == samlsp.ErrNoSession {
@@ -120,7 +120,7 @@ func wireguardConfigHandler(w *Web) {
 
 func configureHandler(w *Web) {
 	if config.FindInfo().Configured {
-		w.Redirect(backlink + "?error=configured")
+		w.Redirect(subdir + "?error=configured")
 		return
 	}
 
@@ -134,13 +134,13 @@ func configureHandler(w *Web) {
 	password := w.r.FormValue("password")
 
 	if !validEmail.MatchString(email) || !validPassword.MatchString(password) || email != emailConfirm {
-		w.Redirect(backlink + "/configure?error=invalid")
+		w.Redirect(subdir + "/configure?error=invalid")
 		return
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		w.Redirect(backlink + "/forgot?error=bcrypt")
+		w.Redirect(subdir + "/forgot?error=bcrypt")
 		return
 	}
 	config.UpdateInfo(func(i *Info) error {
@@ -154,7 +154,7 @@ func configureHandler(w *Web) {
 		Error(w.w, err)
 		return
 	}
-	w.Redirect(backlink + "/settings?success=configured")
+	w.Redirect(subdir + "/settings?success=configured")
 }
 
 func forgotHandler(w *Web) {
@@ -168,20 +168,20 @@ func forgotHandler(w *Web) {
 	password := w.r.FormValue("password")
 
 	if email != "" && !validEmail.MatchString(email) {
-		w.Redirect(backlink + "/forgot?error=invalid")
+		w.Redirect(subdir + "/forgot?error=invalid")
 		return
 	}
 	if secret != "" && !validString.MatchString(secret) {
-		w.Redirect(backlink + "/forgot?error=invalid")
+		w.Redirect(subdir + "/forgot?error=invalid")
 		return
 	}
 	if email != "" && secret != "" && !validPassword.MatchString(password) {
-		w.Redirect(backlink + "/forgot?error=invalid&email=%s&secret=%s", email, secret)
+		w.Redirect(subdir+"/forgot?error=invalid&email=%s&secret=%s", email, secret)
 		return
 	}
 
 	if email != config.FindInfo().Email {
-		w.Redirect(backlink + "/forgot?error=invalid")
+		w.Redirect(subdir + "/forgot?error=invalid")
 		return
 	}
 
@@ -203,18 +203,18 @@ func forgotHandler(w *Web) {
 			}
 		}()
 
-		w.Redirect(backlink + "/forgot?success=forgot")
+		w.Redirect(subdir + "/forgot?success=forgot")
 		return
 	}
 
 	if secret != config.FindInfo().Secret {
-		w.Redirect(backlink + "/forgot?error=invalid")
+		w.Redirect(subdir + "/forgot?error=invalid")
 		return
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		w.Redirect(backlink + "/forgot?error=bcrypt")
+		w.Redirect(subdir + "/forgot?error=bcrypt")
 		return
 	}
 	config.UpdateInfo(func(i *Info) error {
@@ -227,12 +227,12 @@ func forgotHandler(w *Web) {
 		Error(w.w, err)
 		return
 	}
-	w.Redirect(backlink)
+	w.Redirect(subdir)
 }
 
 func signoutHandler(w *Web) {
 	w.SignoutSession()
-	w.Redirect(backlink + "/signin")
+	w.Redirect(subdir + "/signin")
 }
 
 func signinHandler(w *Web) {
@@ -246,18 +246,18 @@ func signinHandler(w *Web) {
 	passcode := w.r.FormValue("totp")
 
 	if email != config.FindInfo().Email {
-		w.Redirect(backlink + "/signin?error=invalid")
+		w.Redirect(subdir + "/signin?error=invalid")
 		return
 	}
 
 	if err := bcrypt.CompareHashAndPassword(config.FindInfo().Password, []byte(password)); err != nil {
-		w.Redirect(backlink + "/signin?error=invalid")
+		w.Redirect(subdir + "/signin?error=invalid")
 		return
 	}
 
 	if config.FindInfo().TotpKey != "" && !totp.Validate(passcode, config.FindInfo().TotpKey) {
 		// Totp has been configured and the provided code doesn't match
-		w.Redirect(backlink + "/signin?error=invalid")
+		w.Redirect(subdir + "/signin?error=invalid")
 		return
 	}
 
@@ -266,7 +266,7 @@ func signinHandler(w *Web) {
 		return
 	}
 
-	w.Redirect(backlink)
+	w.Redirect(subdir)
 }
 
 func totpQRHandler(w *Web) {
@@ -277,7 +277,7 @@ func totpQRHandler(w *Web) {
 
 	if config.Info.TotpKey != "" {
 		// TOTP is already configured, don't allow the current one to be leaked
-		w.Redirect(backlink + "/")
+		w.Redirect(subdir + "/")
 		return
 	}
 
@@ -322,7 +322,7 @@ func userEditHandler(w *Web) {
 	}
 
 	if w.User.ID == user.ID {
-		w.Redirect(backlink + "/user/edit/%s", user.ID)
+		w.Redirect(subdir+"/user/edit/%s", user.ID)
 		return
 	}
 
@@ -333,7 +333,7 @@ func userEditHandler(w *Web) {
 		return nil
 	})
 
-	w.Redirect(backlink + "/user/edit/%s?success=edituser", user.ID)
+	w.Redirect(subdir+"/user/edit/%s?success=edituser", user.ID)
 }
 
 func userDeleteHandler(w *Web) {
@@ -351,7 +351,7 @@ func userDeleteHandler(w *Web) {
 		return
 	}
 	if w.User.ID == user.ID {
-		w.Redirect(backlink + "/user/edit/%s?error=deleteuser", user.ID)
+		w.Redirect(subdir+"/user/edit/%s?error=deleteuser", user.ID)
 		return
 	}
 
@@ -364,7 +364,7 @@ func userDeleteHandler(w *Web) {
 	for _, profile := range config.ListProfilesByUser(user.ID) {
 		if err := deleteProfile(profile); err != nil {
 			logger.Errorf("delete profile failed: %s", err)
-			w.Redirect(backlink + "/profile/delete?error=deleteprofile")
+			w.Redirect(subdir + "/profile/delete?error=deleteprofile")
 			return
 		}
 	}
@@ -373,7 +373,7 @@ func userDeleteHandler(w *Web) {
 		Error(w.w, err)
 		return
 	}
-	w.Redirect(backlink + "?success=deleteuser")
+	w.Redirect(subdir + "?success=deleteuser")
 }
 
 func profileAddHandler(w *Web) {
@@ -391,7 +391,7 @@ func profileAddHandler(w *Web) {
 	}
 
 	if name == "" {
-		w.Redirect(backlink + "?error=profilename")
+		w.Redirect(subdir + "?error=profilename")
 		return
 	}
 
@@ -403,14 +403,14 @@ func profileAddHandler(w *Web) {
 	}
 
 	if len(config.ListProfiles()) >= maxProfiles {
-		w.Redirect(backlink + "?error=addprofile")
+		w.Redirect(subdir + "?error=addprofile")
 		return
 	}
 
 	profile, err := config.AddProfile(userID, name, platform)
 	if err != nil {
 		logger.Warn(err)
-		w.Redirect(backlink + "?error=addprofile")
+		w.Redirect(subdir + "?error=addprofile")
 		return
 	}
 
@@ -527,11 +527,11 @@ WGCLIENT
 		f, _ := os.Create("/tmp/error.txt")
 		errstr := fmt.Sprintln(err)
 		f.WriteString(errstr)
-		w.Redirect(backlink + "?error=addprofile")
+		w.Redirect(subdir + "?error=addprofile")
 		return
 	}
 
-	w.Redirect(backlink + "/profile/connect/%s?success=addprofile", profile.ID)
+	w.Redirect(subdir+"/profile/connect/%s?success=addprofile", profile.ID)
 }
 
 func profileConnectHandler(w *Web) {
@@ -570,18 +570,18 @@ func profileDeleteHandler(w *Web) {
 	}
 	if err := deleteProfile(profile); err != nil {
 		logger.Errorf("delete profile failed: %s", err)
-		w.Redirect(backlink + "/profile/delete?error=deleteprofile")
+		w.Redirect(subdir + "/profile/delete?error=deleteprofile")
 		return
 	}
 	if len(profile.UserID) > 0 && w.Admin {
-		w.Redirect(backlink + "/user/edit/%s?success=deleteprofile", profile.UserID)
+		w.Redirect(subdir+"/user/edit/%s?success=deleteprofile", profile.UserID)
 		return
 	}
-	w.Redirect(backlink + "?success=deleteprofile")
+	w.Redirect(subdir + "?success=deleteprofile")
 }
 
 func indexHandler(w *Web) {
-	w.Redirect(backlink)
+	w.Redirect(subdir)
 }
 
 func rootIndexHandler(w *Web) {
@@ -627,7 +627,7 @@ func settingsHandler(w *Web) {
 	if len(samlMetadata) > 0 {
 		if err := configureSAML(); err != nil {
 			logger.Warnf("configuring SAML failed: %s", err)
-			w.Redirect(backlink + "/settings?error=saml")
+			w.Redirect(subdir + "/settings?error=saml")
 		}
 	} else {
 		samlSP = nil
@@ -635,18 +635,18 @@ func settingsHandler(w *Web) {
 
 	if currentPassword != "" || newPassword != "" {
 		if !validPassword.MatchString(newPassword) {
-			w.Redirect(backlink + "/settings?error=invalid")
+			w.Redirect(subdir + "/settings?error=invalid")
 			return
 		}
 
 		if err := bcrypt.CompareHashAndPassword(config.FindInfo().Password, []byte(currentPassword)); err != nil {
-			w.Redirect(backlink + "/settings?error=invalid")
+			w.Redirect(subdir + "/settings?error=invalid")
 			return
 		}
 
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 		if err != nil {
-			w.Redirect(backlink + "/settings?error=bcrypt")
+			w.Redirect(subdir + "/settings?error=bcrypt")
 			return
 		}
 
@@ -659,24 +659,24 @@ func settingsHandler(w *Web) {
 	if resetTotp == "true" {
 		err := config.ResetTotp()
 		if err != nil {
-			w.Redirect(backlink + "/settings?error=totp")
+			w.Redirect(subdir + "/settings?error=totp")
 			return
 		}
 
-		w.Redirect(backlink + "/settings?success=totp")
+		w.Redirect(subdir + "/settings?success=totp")
 		return
 	}
 
 	if config.Info.TotpKey == "" && totpCode != "" {
 		if !totp.Validate(totpCode, tempTotpKey.Secret()) {
-			w.Redirect(backlink + "/settings?error=totp")
+			w.Redirect(subdir + "/settings?error=totp")
 			return
 		}
 		config.Info.TotpKey = tempTotpKey.Secret()
 		config.save()
 	}
 
-	w.Redirect(backlink + "/settings?success=settings")
+	w.Redirect(subdir + "/settings?success=settings")
 }
 
 func helpHandler(w *Web) {

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -120,7 +120,7 @@ func wireguardConfigHandler(w *Web) {
 
 func configureHandler(w *Web) {
 	if config.FindInfo().Configured {
-		w.Redirect(backlink + "/?error=configured")
+		w.Redirect(backlink + "?error=configured")
 		return
 	}
 
@@ -176,7 +176,7 @@ func forgotHandler(w *Web) {
 		return
 	}
 	if email != "" && secret != "" && !validPassword.MatchString(password) {
-		w.Redirect(backlink + "/forgot?error=invalid&email=%s&secret=%s", email, secret)
+		w.Redirect(backlink+"/forgot?error=invalid&email=%s&secret=%s", email, secret)
 		return
 	}
 
@@ -322,7 +322,7 @@ func userEditHandler(w *Web) {
 	}
 
 	if w.User.ID == user.ID {
-		w.Redirect(backlink + "/user/edit/%s", user.ID)
+		w.Redirect(backlink+"/user/edit/%s", user.ID)
 		return
 	}
 
@@ -333,7 +333,7 @@ func userEditHandler(w *Web) {
 		return nil
 	})
 
-	w.Redirect(backlink + "/user/edit/%s?success=edituser", user.ID)
+	w.Redirect(backlink+"/user/edit/%s?success=edituser", user.ID)
 }
 
 func userDeleteHandler(w *Web) {
@@ -351,7 +351,7 @@ func userDeleteHandler(w *Web) {
 		return
 	}
 	if w.User.ID == user.ID {
-		w.Redirect(backlink + "/user/edit/%s?error=deleteuser", user.ID)
+		w.Redirect(backlink+"/user/edit/%s?error=deleteuser", user.ID)
 		return
 	}
 
@@ -373,7 +373,7 @@ func userDeleteHandler(w *Web) {
 		Error(w.w, err)
 		return
 	}
-	w.Redirect(backlink + "/?success=deleteuser")
+	w.Redirect(backlink + "?success=deleteuser")
 }
 
 func profileAddHandler(w *Web) {
@@ -391,7 +391,7 @@ func profileAddHandler(w *Web) {
 	}
 
 	if name == "" {
-		w.Redirect(backlink + "/?error=profilename")
+		w.Redirect(backlink + "?error=profilename")
 		return
 	}
 
@@ -403,14 +403,14 @@ func profileAddHandler(w *Web) {
 	}
 
 	if len(config.ListProfiles()) >= maxProfiles {
-		w.Redirect(backlink + "/?error=addprofile")
+		w.Redirect(backlink + "?error=addprofile")
 		return
 	}
 
 	profile, err := config.AddProfile(userID, name, platform)
 	if err != nil {
 		logger.Warn(err)
-		w.Redirect(backlink + "/?error=addprofile")
+		w.Redirect(backlink + "?error=addprofile")
 		return
 	}
 
@@ -527,11 +527,11 @@ WGCLIENT
 		f, _ := os.Create("/tmp/error.txt")
 		errstr := fmt.Sprintln(err)
 		f.WriteString(errstr)
-		w.Redirect(backlink + "/?error=addprofile")
+		w.Redirect(backlink + "?error=addprofile")
 		return
 	}
 
-	w.Redirect(backlink + "/profile/connect/%s?success=addprofile", profile.ID)
+	w.Redirect(backlink+"/profile/connect/%s?success=addprofile", profile.ID)
 }
 
 func profileConnectHandler(w *Web) {
@@ -574,10 +574,10 @@ func profileDeleteHandler(w *Web) {
 		return
 	}
 	if len(profile.UserID) > 0 && w.Admin {
-		w.Redirect(backlink + "/user/edit/%s?success=deleteprofile", profile.UserID)
+		w.Redirect(backlink+"/user/edit/%s?success=deleteprofile", profile.UserID)
 		return
 	}
-	w.Redirect(backlink + "/?success=deleteprofile")
+	w.Redirect(backlink + "?success=deleteprofile")
 }
 
 func indexHandler(w *Web) {

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -176,7 +176,7 @@ func forgotHandler(w *Web) {
 		return
 	}
 	if email != "" && secret != "" && !validPassword.MatchString(password) {
-		w.Redirect(subdir+"/forgot?error=invalid&email=%s&secret=%s", email, secret)
+		w.Redirect(subdir + "/forgot?error=invalid&email=%s&secret=%s", email, secret)
 		return
 	}
 
@@ -322,7 +322,7 @@ func userEditHandler(w *Web) {
 	}
 
 	if w.User.ID == user.ID {
-		w.Redirect(subdir+"/user/edit/%s", user.ID)
+		w.Redirect(subdir + "/user/edit/%s", user.ID)
 		return
 	}
 
@@ -333,7 +333,7 @@ func userEditHandler(w *Web) {
 		return nil
 	})
 
-	w.Redirect(subdir+"/user/edit/%s?success=edituser", user.ID)
+	w.Redirect(subdir + "/user/edit/%s?success=edituser", user.ID)
 }
 
 func userDeleteHandler(w *Web) {
@@ -351,7 +351,7 @@ func userDeleteHandler(w *Web) {
 		return
 	}
 	if w.User.ID == user.ID {
-		w.Redirect(subdir+"/user/edit/%s?error=deleteuser", user.ID)
+		w.Redirect(subdir + "/user/edit/%s?error=deleteuser", user.ID)
 		return
 	}
 
@@ -531,7 +531,7 @@ WGCLIENT
 		return
 	}
 
-	w.Redirect(subdir+"/profile/connect/%s?success=addprofile", profile.ID)
+	w.Redirect(subdir + "/profile/connect/%s?success=addprofile", profile.ID)
 }
 
 func profileConnectHandler(w *Web) {
@@ -574,7 +574,7 @@ func profileDeleteHandler(w *Web) {
 		return
 	}
 	if len(profile.UserID) > 0 && w.Admin {
-		w.Redirect(subdir+"/user/edit/%s?success=deleteprofile", profile.UserID)
+		w.Redirect(subdir + "/user/edit/%s?success=deleteprofile", profile.UserID)
 		return
 	}
 	w.Redirect(subdir + "?success=deleteprofile")

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -18,19 +18,19 @@ import (
 	qrcode "github.com/skip2/go-qrcode"
 )
 
-func getEnv(key, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return fallback
-}
-
 var (
 	validEmail    = regexp.MustCompile(`^[ -~]+@[ -~]+$`)
 	validPassword = regexp.MustCompile(`^[ -~]{6,200}$`)
 	validString   = regexp.MustCompile(`^[ -~]{1,200}$`)
 	maxProfiles   = 250
 )
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
 
 // Handles the sign in part separately from the SAML
 func ssoHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -87,7 +87,7 @@ var (
 
 func init() {
 	cli.StringVar(&datadir, "datadir", "/data", "data dir")
-	cli.StringVar(&subdir, "subdir", "", "subdir, without trailing slash (optional)")
+	cli.StringVar(&subdir, "subdir", "", "[optional] URL path(without hostname) to subspace instance, without trailing slash")
 	cli.StringVar(&httpHost, "http-host", "", "HTTP host")
 	cli.StringVar(&httpAddr, "http-addr", ":80", "HTTP listen address")
 	cli.BoolVar(&httpInsecure, "http-insecure", false, "enable sessions cookies for http (no https) not recommended")

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -45,8 +45,8 @@ var (
 	// Insecure http cookies (only recommended for internal LANs/VPNs)
 	httpInsecure bool
 
-	// backlink
-	backlink string
+	// subdir
+	subdir string
 
 	// show version
 	showVersion bool
@@ -87,7 +87,7 @@ var (
 
 func init() {
 	cli.StringVar(&datadir, "datadir", "/data", "data dir")
-	cli.StringVar(&backlink, "backlink", "", "backlink, without trailing slash (optional)")
+	cli.StringVar(&subdir, "subdir", "", "subdir, without trailing slash (optional)")
 	cli.StringVar(&httpHost, "http-host", "", "HTTP host")
 	cli.StringVar(&httpAddr, "http-addr", ":80", "HTTP listen address")
 	cli.BoolVar(&httpInsecure, "http-insecure", false, "enable sessions cookies for http (no https) not recommended")
@@ -169,42 +169,42 @@ func main() {
 	//
 	r := &httprouter.Router{}
 
-	r.GET(backlink, Log(WebHandler(rootIndexHandler, "index")))
-	r.GET(backlink + "/", Log(WebHandler(indexHandler, "index")))
-	r.GET(backlink + "/help", Log(WebHandler(helpHandler, "help")))
-	r.GET(backlink + "/configure", Log(WebHandler(configureHandler, "configure")))
-	r.POST(backlink + "/configure", Log(WebHandler(configureHandler, "configure")))
+	r.GET(subdir, Log(WebHandler(rootIndexHandler, "index")))
+	r.GET(subdir+"/", Log(WebHandler(indexHandler, "index")))
+	r.GET(subdir+"/help", Log(WebHandler(helpHandler, "help")))
+	r.GET(subdir+"/configure", Log(WebHandler(configureHandler, "configure")))
+	r.POST(subdir+"/configure", Log(WebHandler(configureHandler, "configure")))
 
 	// SAML
-	r.GET(backlink + "/sso", Log(ssoHandler))
-	r.GET(backlink + "/saml/metadata", Log(samlHandler))
-	r.POST(backlink + "/saml/metadata", Log(samlHandler))
-	r.GET(backlink + "/saml/acs", Log(samlHandler))
-	r.POST(backlink + "/saml/acs", Log(samlHandler))
+	r.GET(subdir+"/sso", Log(ssoHandler))
+	r.GET(subdir+"/saml/metadata", Log(samlHandler))
+	r.POST(subdir+"/saml/metadata", Log(samlHandler))
+	r.GET(subdir+"/saml/acs", Log(samlHandler))
+	r.POST(subdir+"/saml/acs", Log(samlHandler))
 
-	r.GET(backlink + "/totp/image", Log(WebHandler(totpQRHandler, "totp/image")))
-	r.GET(backlink + "/signin", Log(WebHandler(signinHandler, "signin")))
-	r.GET(backlink + "/signout", Log(WebHandler(signoutHandler, "signout")))
-	r.POST(backlink + "/signin", Log(WebHandler(signinHandler, "signin")))
-	r.GET(backlink + "/forgot", Log(WebHandler(forgotHandler, "forgot")))
-	r.POST(backlink + "/forgot", Log(WebHandler(forgotHandler, "forgot")))
+	r.GET(subdir+"/totp/image", Log(WebHandler(totpQRHandler, "totp/image")))
+	r.GET(subdir+"/signin", Log(WebHandler(signinHandler, "signin")))
+	r.GET(subdir+"/signout", Log(WebHandler(signoutHandler, "signout")))
+	r.POST(subdir+"/signin", Log(WebHandler(signinHandler, "signin")))
+	r.GET(subdir+"/forgot", Log(WebHandler(forgotHandler, "forgot")))
+	r.POST(subdir+"/forgot", Log(WebHandler(forgotHandler, "forgot")))
 
-	r.GET(backlink + "/settings", Log(WebHandler(settingsHandler, "settings")))
-	r.POST(backlink + "/settings", Log(WebHandler(settingsHandler, "settings")))
+	r.GET(subdir+"/settings", Log(WebHandler(settingsHandler, "settings")))
+	r.POST(subdir+"/settings", Log(WebHandler(settingsHandler, "settings")))
 
-	r.GET(backlink + "/user/edit/:user", Log(WebHandler(userEditHandler, "user/edit")))
-	r.POST(backlink + "/user/edit", Log(WebHandler(userEditHandler, "user/edit")))
-	r.GET(backlink + "/user/delete/:user", Log(WebHandler(userDeleteHandler, "user/delete")))
-	r.POST(backlink + "/user/delete", Log(WebHandler(userDeleteHandler, "user/delete")))
+	r.GET(subdir+"/user/edit/:user", Log(WebHandler(userEditHandler, "user/edit")))
+	r.POST(subdir+"/user/edit", Log(WebHandler(userEditHandler, "user/edit")))
+	r.GET(subdir+"/user/delete/:user", Log(WebHandler(userDeleteHandler, "user/delete")))
+	r.POST(subdir+"/user/delete", Log(WebHandler(userDeleteHandler, "user/delete")))
 
-	r.GET(backlink + "/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
-	r.POST(backlink + "/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
-	r.GET(backlink + "/profile/connect/:profile", Log(WebHandler(profileConnectHandler, "profile/connect")))
-	r.GET(backlink + "/profile/delete/:profile", Log(WebHandler(profileDeleteHandler, "profile/delete")))
-	r.POST(backlink + "/profile/delete", Log(WebHandler(profileDeleteHandler, "profile/delete")))
-	r.GET(backlink + "/profile/config/wireguard/:profile", Log(WebHandler(wireguardConfigHandler, "profile/config/wireguard")))
-	r.GET(backlink + "/profile/qrconfig/wireguard/:profile", Log(WebHandler(wireguardQRConfigHandler, "profile/qrconfig/wireguard")))
-	r.GET(backlink + "/static/*path", staticHandler)
+	r.GET(subdir+"/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
+	r.POST(subdir+"/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
+	r.GET(subdir+"/profile/connect/:profile", Log(WebHandler(profileConnectHandler, "profile/connect")))
+	r.GET(subdir+"/profile/delete/:profile", Log(WebHandler(profileDeleteHandler, "profile/delete")))
+	r.POST(subdir+"/profile/delete", Log(WebHandler(profileDeleteHandler, "profile/delete")))
+	r.GET(subdir+"/profile/config/wireguard/:profile", Log(WebHandler(wireguardConfigHandler, "profile/config/wireguard")))
+	r.GET(subdir+"/profile/qrconfig/wireguard/:profile", Log(WebHandler(wireguardQRConfigHandler, "profile/qrconfig/wireguard")))
+	r.GET(subdir+"/static/*path", staticHandler)
 
 	//
 	// Server
@@ -227,12 +227,12 @@ func main() {
 			hostport = httpHost
 		}
 		if len(httpIP) == 0 {
-		  hostport = "[::]:" + httpPort
+			hostport = "[::]:" + httpPort
 		}
 		logger.Infof("Subspace version: %s %s", version, &url.URL{
 			Scheme: "http",
 			Host:   hostport,
-			Path:   backlink,
+			Path:   subdir,
 		})
 		logger.Fatal(httpd.ListenAndServe())
 	}
@@ -258,7 +258,7 @@ func main() {
 	// http redirect to https and Let's Encrypt auth
 	go func() {
 		redir := httprouter.New()
-		redir.GET(backlink + "/*path", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		redir.GET(subdir+"/*path", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			r.URL.Scheme = "https"
 			r.URL.Host = httpHost
 			http.Redirect(w, r, r.URL.String(), http.StatusFound)
@@ -326,7 +326,7 @@ func main() {
 	logger.Infof("Subspace version: %s %s", version, &url.URL{
 		Scheme: "https",
 		Host:   hostport,
-		Path:   backlink,
+		Path:   subdir,
 	})
 	logger.Fatal(httpsd.Serve(tlsListener))
 }
@@ -385,7 +385,7 @@ func configureSAML() error {
 	rootURL := url.URL{
 		Scheme: "https",
 		Host:   httpHost,
-		Path:   backlink,
+		Path:   subdir,
 	}
 
 	if httpInsecure {

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -324,7 +324,7 @@ func main() {
 	logger.Infof("Subspace version: %s %s", version, &url.URL{
 		Scheme: "https",
 		Host:   hostport,
-		Path:   backlink + "/",
+		Path:   backlink,
 	})
 	logger.Fatal(httpsd.Serve(tlsListener))
 }

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -168,6 +168,8 @@ func main() {
 	// Routes
 	//
 	r := &httprouter.Router{}
+
+	r.GET(backlink, Log(WebHandler(rootIndexHandler, "index")))
 	r.GET(backlink + "/", Log(WebHandler(indexHandler, "index")))
 	r.GET(backlink + "/help", Log(WebHandler(helpHandler, "help")))
 	r.GET(backlink + "/configure", Log(WebHandler(configureHandler, "configure")))
@@ -383,7 +385,7 @@ func configureSAML() error {
 	rootURL := url.URL{
 		Scheme: "https",
 		Host:   httpHost,
-		Path:   backlink + "/",
+		Path:   backlink,
 	}
 
 	if httpInsecure {

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -87,7 +87,7 @@ var (
 
 func init() {
 	cli.StringVar(&datadir, "datadir", "/data", "data dir")
-	cli.StringVar(&backlink, "backlink", "/", "backlink (optional)")
+	cli.StringVar(&backlink, "backlink", "", "backlink, without trailing slash (optional)")
 	cli.StringVar(&httpHost, "http-host", "", "HTTP host")
 	cli.StringVar(&httpAddr, "http-addr", ":80", "HTTP listen address")
 	cli.BoolVar(&httpInsecure, "http-insecure", false, "enable sessions cookies for http (no https) not recommended")
@@ -168,41 +168,41 @@ func main() {
 	// Routes
 	//
 	r := &httprouter.Router{}
-	r.GET("/", Log(WebHandler(indexHandler, "index")))
-	r.GET("/help", Log(WebHandler(helpHandler, "help")))
-	r.GET("/configure", Log(WebHandler(configureHandler, "configure")))
-	r.POST("/configure", Log(WebHandler(configureHandler, "configure")))
+	r.GET(backlink + "/", Log(WebHandler(indexHandler, "index")))
+	r.GET(backlink + "/help", Log(WebHandler(helpHandler, "help")))
+	r.GET(backlink + "/configure", Log(WebHandler(configureHandler, "configure")))
+	r.POST(backlink + "/configure", Log(WebHandler(configureHandler, "configure")))
 
 	// SAML
-	r.GET("/sso", Log(ssoHandler))
-	r.GET("/saml/metadata", Log(samlHandler))
-	r.POST("/saml/metadata", Log(samlHandler))
-	r.GET("/saml/acs", Log(samlHandler))
-	r.POST("/saml/acs", Log(samlHandler))
+	r.GET(backlink + "/sso", Log(ssoHandler))
+	r.GET(backlink + "/saml/metadata", Log(samlHandler))
+	r.POST(backlink + "/saml/metadata", Log(samlHandler))
+	r.GET(backlink + "/saml/acs", Log(samlHandler))
+	r.POST(backlink + "/saml/acs", Log(samlHandler))
 
-	r.GET("/totp/image", Log(WebHandler(totpQRHandler, "totp/image")))
-	r.GET("/signin", Log(WebHandler(signinHandler, "signin")))
-	r.GET("/signout", Log(WebHandler(signoutHandler, "signout")))
-	r.POST("/signin", Log(WebHandler(signinHandler, "signin")))
-	r.GET("/forgot", Log(WebHandler(forgotHandler, "forgot")))
-	r.POST("/forgot", Log(WebHandler(forgotHandler, "forgot")))
+	r.GET(backlink + "/totp/image", Log(WebHandler(totpQRHandler, "totp/image")))
+	r.GET(backlink + "/signin", Log(WebHandler(signinHandler, "signin")))
+	r.GET(backlink + "/signout", Log(WebHandler(signoutHandler, "signout")))
+	r.POST(backlink + "/signin", Log(WebHandler(signinHandler, "signin")))
+	r.GET(backlink + "/forgot", Log(WebHandler(forgotHandler, "forgot")))
+	r.POST(backlink + "/forgot", Log(WebHandler(forgotHandler, "forgot")))
 
-	r.GET("/settings", Log(WebHandler(settingsHandler, "settings")))
-	r.POST("/settings", Log(WebHandler(settingsHandler, "settings")))
+	r.GET(backlink + "/settings", Log(WebHandler(settingsHandler, "settings")))
+	r.POST(backlink + "/settings", Log(WebHandler(settingsHandler, "settings")))
 
-	r.GET("/user/edit/:user", Log(WebHandler(userEditHandler, "user/edit")))
-	r.POST("/user/edit", Log(WebHandler(userEditHandler, "user/edit")))
-	r.GET("/user/delete/:user", Log(WebHandler(userDeleteHandler, "user/delete")))
-	r.POST("/user/delete", Log(WebHandler(userDeleteHandler, "user/delete")))
+	r.GET(backlink + "/user/edit/:user", Log(WebHandler(userEditHandler, "user/edit")))
+	r.POST(backlink + "/user/edit", Log(WebHandler(userEditHandler, "user/edit")))
+	r.GET(backlink + "/user/delete/:user", Log(WebHandler(userDeleteHandler, "user/delete")))
+	r.POST(backlink + "/user/delete", Log(WebHandler(userDeleteHandler, "user/delete")))
 
-	r.GET("/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
-	r.POST("/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
-	r.GET("/profile/connect/:profile", Log(WebHandler(profileConnectHandler, "profile/connect")))
-	r.GET("/profile/delete/:profile", Log(WebHandler(profileDeleteHandler, "profile/delete")))
-	r.POST("/profile/delete", Log(WebHandler(profileDeleteHandler, "profile/delete")))
-	r.GET("/profile/config/wireguard/:profile", Log(WebHandler(wireguardConfigHandler, "profile/config/wireguard")))
-	r.GET("/profile/qrconfig/wireguard/:profile", Log(WebHandler(wireguardQRConfigHandler, "profile/qrconfig/wireguard")))
-	r.GET("/static/*path", staticHandler)
+	r.GET(backlink + "/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
+	r.POST(backlink + "/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
+	r.GET(backlink + "/profile/connect/:profile", Log(WebHandler(profileConnectHandler, "profile/connect")))
+	r.GET(backlink + "/profile/delete/:profile", Log(WebHandler(profileDeleteHandler, "profile/delete")))
+	r.POST(backlink + "/profile/delete", Log(WebHandler(profileDeleteHandler, "profile/delete")))
+	r.GET(backlink + "/profile/config/wireguard/:profile", Log(WebHandler(wireguardConfigHandler, "profile/config/wireguard")))
+	r.GET(backlink + "/profile/qrconfig/wireguard/:profile", Log(WebHandler(wireguardQRConfigHandler, "profile/qrconfig/wireguard")))
+	r.GET(backlink + "/static/*path", staticHandler)
 
 	//
 	// Server
@@ -253,7 +253,7 @@ func main() {
 	// http redirect to https and Let's Encrypt auth
 	go func() {
 		redir := httprouter.New()
-		redir.GET("/*path", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		redir.GET(backlink + "/*path", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			r.URL.Scheme = "https"
 			r.URL.Host = httpHost
 			http.Redirect(w, r, r.URL.String(), http.StatusFound)
@@ -318,7 +318,7 @@ func main() {
 	logger.Infof("Subspace version: %s %s", version, &url.URL{
 		Scheme: "https",
 		Host:   hostport,
-		Path:   "/",
+		Path:   backlink + "/",
 	})
 	logger.Fatal(httpsd.Serve(tlsListener))
 }
@@ -377,7 +377,7 @@ func configureSAML() error {
 	rootURL := url.URL{
 		Scheme: "https",
 		Host:   httpHost,
-		Path:   "/",
+		Path:   backlink + "/",
 	}
 
 	if httpInsecure {

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -224,10 +224,13 @@ func main() {
 		if httpPort == "80" {
 			hostport = httpHost
 		}
+		if len(httpIP) == 0 {
+		  hostport = "[::]:" + httpPort
+		}
 		logger.Infof("Subspace version: %s %s", version, &url.URL{
 			Scheme: "http",
 			Host:   hostport,
-			Path:   httpPrefix,
+			Path:   backlink,
 		})
 		logger.Fatal(httpd.ListenAndServe())
 	}
@@ -314,6 +317,9 @@ func main() {
 	hostport := net.JoinHostPort(httpHost, httpPort)
 	if httpPort == "443" {
 		hostport = httpHost
+	}
+	if len(httpIP) == 0 {
+		hostport = "[::]:" + httpPort
 	}
 	logger.Infof("Subspace version: %s %s", version, &url.URL{
 		Scheme: "https",

--- a/cmd/subspace/main.go
+++ b/cmd/subspace/main.go
@@ -170,41 +170,41 @@ func main() {
 	r := &httprouter.Router{}
 
 	r.GET(subdir, Log(WebHandler(rootIndexHandler, "index")))
-	r.GET(subdir+"/", Log(WebHandler(indexHandler, "index")))
-	r.GET(subdir+"/help", Log(WebHandler(helpHandler, "help")))
-	r.GET(subdir+"/configure", Log(WebHandler(configureHandler, "configure")))
-	r.POST(subdir+"/configure", Log(WebHandler(configureHandler, "configure")))
+	r.GET(subdir + "/", Log(WebHandler(indexHandler, "index")))
+	r.GET(subdir + "/help", Log(WebHandler(helpHandler, "help")))
+	r.GET(subdir + "/configure", Log(WebHandler(configureHandler, "configure")))
+	r.POST(subdir + "/configure", Log(WebHandler(configureHandler, "configure")))
 
 	// SAML
-	r.GET(subdir+"/sso", Log(ssoHandler))
-	r.GET(subdir+"/saml/metadata", Log(samlHandler))
-	r.POST(subdir+"/saml/metadata", Log(samlHandler))
-	r.GET(subdir+"/saml/acs", Log(samlHandler))
-	r.POST(subdir+"/saml/acs", Log(samlHandler))
+	r.GET(subdir + "/sso", Log(ssoHandler))
+	r.GET(subdir + "/saml/metadata", Log(samlHandler))
+	r.POST(subdir + "/saml/metadata", Log(samlHandler))
+	r.GET(subdir + "/saml/acs", Log(samlHandler))
+	r.POST(subdir + "/saml/acs", Log(samlHandler))
 
-	r.GET(subdir+"/totp/image", Log(WebHandler(totpQRHandler, "totp/image")))
-	r.GET(subdir+"/signin", Log(WebHandler(signinHandler, "signin")))
-	r.GET(subdir+"/signout", Log(WebHandler(signoutHandler, "signout")))
-	r.POST(subdir+"/signin", Log(WebHandler(signinHandler, "signin")))
-	r.GET(subdir+"/forgot", Log(WebHandler(forgotHandler, "forgot")))
-	r.POST(subdir+"/forgot", Log(WebHandler(forgotHandler, "forgot")))
+	r.GET(subdir + "/totp/image", Log(WebHandler(totpQRHandler, "totp/image")))
+	r.GET(subdir + "/signin", Log(WebHandler(signinHandler, "signin")))
+	r.GET(subdir + "/signout", Log(WebHandler(signoutHandler, "signout")))
+	r.POST(subdir + "/signin", Log(WebHandler(signinHandler, "signin")))
+	r.GET(subdir + "/forgot", Log(WebHandler(forgotHandler, "forgot")))
+	r.POST(subdir + "/forgot", Log(WebHandler(forgotHandler, "forgot")))
 
-	r.GET(subdir+"/settings", Log(WebHandler(settingsHandler, "settings")))
-	r.POST(subdir+"/settings", Log(WebHandler(settingsHandler, "settings")))
+	r.GET(subdir + "/settings", Log(WebHandler(settingsHandler, "settings")))
+	r.POST(subdir + "/settings", Log(WebHandler(settingsHandler, "settings")))
 
-	r.GET(subdir+"/user/edit/:user", Log(WebHandler(userEditHandler, "user/edit")))
-	r.POST(subdir+"/user/edit", Log(WebHandler(userEditHandler, "user/edit")))
-	r.GET(subdir+"/user/delete/:user", Log(WebHandler(userDeleteHandler, "user/delete")))
-	r.POST(subdir+"/user/delete", Log(WebHandler(userDeleteHandler, "user/delete")))
+	r.GET(subdir + "/user/edit/:user", Log(WebHandler(userEditHandler, "user/edit")))
+	r.POST(subdir + "/user/edit", Log(WebHandler(userEditHandler, "user/edit")))
+	r.GET(subdir + "/user/delete/:user", Log(WebHandler(userDeleteHandler, "user/delete")))
+	r.POST(subdir + "/user/delete", Log(WebHandler(userDeleteHandler, "user/delete")))
 
-	r.GET(subdir+"/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
-	r.POST(subdir+"/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
-	r.GET(subdir+"/profile/connect/:profile", Log(WebHandler(profileConnectHandler, "profile/connect")))
-	r.GET(subdir+"/profile/delete/:profile", Log(WebHandler(profileDeleteHandler, "profile/delete")))
-	r.POST(subdir+"/profile/delete", Log(WebHandler(profileDeleteHandler, "profile/delete")))
-	r.GET(subdir+"/profile/config/wireguard/:profile", Log(WebHandler(wireguardConfigHandler, "profile/config/wireguard")))
-	r.GET(subdir+"/profile/qrconfig/wireguard/:profile", Log(WebHandler(wireguardQRConfigHandler, "profile/qrconfig/wireguard")))
-	r.GET(subdir+"/static/*path", staticHandler)
+	r.GET(subdir + "/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
+	r.POST(subdir + "/profile/add", Log(WebHandler(profileAddHandler, "profile/add")))
+	r.GET(subdir + "/profile/connect/:profile", Log(WebHandler(profileConnectHandler, "profile/connect")))
+	r.GET(subdir + "/profile/delete/:profile", Log(WebHandler(profileDeleteHandler, "profile/delete")))
+	r.POST(subdir + "/profile/delete", Log(WebHandler(profileDeleteHandler, "profile/delete")))
+	r.GET(subdir + "/profile/config/wireguard/:profile", Log(WebHandler(wireguardConfigHandler, "profile/config/wireguard")))
+	r.GET(subdir + "/profile/qrconfig/wireguard/:profile", Log(WebHandler(wireguardQRConfigHandler, "profile/qrconfig/wireguard")))
+	r.GET(subdir + "/static/*path", staticHandler)
 
 	//
 	// Server
@@ -258,7 +258,7 @@ func main() {
 	// http redirect to https and Let's Encrypt auth
 	go func() {
 		redir := httprouter.New()
-		redir.GET(subdir+"/*path", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		redir.GET(subdir + "/*path", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			r.URL.Scheme = "https"
 			r.URL.Host = httpHost
 			http.Redirect(w, r, r.URL.String(), http.StatusFound)

--- a/cmd/subspace/web.go
+++ b/cmd/subspace/web.go
@@ -164,13 +164,13 @@ func WebHandler(h func(*Web), section string) httprouter.Handle {
 			TempTotpKey:   tempTotpKey,
 		}
 
-		if section == "signin" || section == "forgot" || section == "configure" {
-			h(web)
+		if !config.FindInfo().Configured {
+			web.Redirect(backlink + "/configure")
 			return
 		}
 
-		if !config.FindInfo().Configured {
-			web.Redirect(backlink + "/configure")
+		if section == "signin" || section == "forgot" || section == "configure" {
+			h(web)
 			return
 		}
 

--- a/cmd/subspace/web.go
+++ b/cmd/subspace/web.go
@@ -304,7 +304,7 @@ func (w *Web) SignoutSession() {
 		http.SetCookie(w.w, &http.Cookie{
 			Name:     SessionCookieNameSSO,
 			Value:    "",
-			Path:     backlink + "/",
+			Path:     backlink,
 			HttpOnly: true,
 			Domain:   httpHost,
 			Secure:   !httpInsecure,
@@ -315,7 +315,7 @@ func (w *Web) SignoutSession() {
 	http.SetCookie(w.w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    "",
-		Path:     backlink + "/",
+		Path:     backlink,
 		HttpOnly: true,
 		Domain:   httpHost,
 		Secure:   !httpInsecure,
@@ -339,7 +339,7 @@ func (w *Web) SigninSession(admin bool, userID string) error {
 	http.SetCookie(w.w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    encoded,
-		Path:     backlink + "/",
+		Path:     backlink,
 		HttpOnly: true,
 		Domain:   httpHost,
 		Secure:   !httpInsecure,

--- a/cmd/subspace/web.go
+++ b/cmd/subspace/web.go
@@ -170,7 +170,7 @@ func WebHandler(h func(*Web), section string) httprouter.Handle {
 		}
 
 		if !config.FindInfo().Configured {
-			web.Redirect("/configure")
+			web.Redirect(backlink + "/configure")
 			return
 		}
 
@@ -243,7 +243,7 @@ func WebHandler(h func(*Web), section string) httprouter.Handle {
 		}
 
 		logger.Warnf("auth: sign in required")
-		web.Redirect("/signin")
+		web.Redirect(backlink + "/signin")
 	}
 }
 
@@ -304,7 +304,7 @@ func (w *Web) SignoutSession() {
 		http.SetCookie(w.w, &http.Cookie{
 			Name:     SessionCookieNameSSO,
 			Value:    "",
-			Path:     "/",
+			Path:     backlink + "/",
 			HttpOnly: true,
 			Domain:   httpHost,
 			Secure:   !httpInsecure,
@@ -315,7 +315,7 @@ func (w *Web) SignoutSession() {
 	http.SetCookie(w.w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    "",
-		Path:     "/",
+		Path:     backlink + "/",
 		HttpOnly: true,
 		Domain:   httpHost,
 		Secure:   !httpInsecure,
@@ -339,7 +339,7 @@ func (w *Web) SigninSession(admin bool, userID string) error {
 	http.SetCookie(w.w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    encoded,
-		Path:     "/",
+		Path:     backlink + "/",
 		HttpOnly: true,
 		Domain:   httpHost,
 		Secure:   !httpInsecure,

--- a/cmd/subspace/web.go
+++ b/cmd/subspace/web.go
@@ -41,14 +41,14 @@ type Web struct {
 	template string
 
 	// Default
-	Backlink string
-	Version  string
-	Request  *http.Request
-	Section  string
-	Time     time.Time
-	Info     Info
-	Admin    bool
-	SAML     *samlsp.Middleware
+	SubDirectory string
+	Version      string
+	Request      *http.Request
+	Section      string
+	Time         time.Time
+	Info         Info
+	Admin        bool
+	SAML         *samlsp.Middleware
 
 	User     User
 	Users    []User
@@ -153,7 +153,7 @@ func WebHandler(h func(*Web), section string) httprouter.Handle {
 			ps:       ps,
 			template: section + ".html",
 
-			Backlink:      backlink,
+			SubDirectory:  subdir,
 			Time:          time.Now(),
 			Version:       version,
 			Request:       r,
@@ -165,7 +165,7 @@ func WebHandler(h func(*Web), section string) httprouter.Handle {
 		}
 
 		if !config.FindInfo().Configured {
-			web.Redirect(backlink + "/configure")
+			web.Redirect(subdir + "/configure")
 			return
 		}
 
@@ -243,7 +243,7 @@ func WebHandler(h func(*Web), section string) httprouter.Handle {
 		}
 
 		logger.Warnf("auth: sign in required")
-		web.Redirect(backlink + "/signin")
+		web.Redirect(subdir + "/signin")
 	}
 }
 
@@ -304,7 +304,7 @@ func (w *Web) SignoutSession() {
 		http.SetCookie(w.w, &http.Cookie{
 			Name:     SessionCookieNameSSO,
 			Value:    "",
-			Path:     backlink,
+			Path:     subdir,
 			HttpOnly: true,
 			Domain:   httpHost,
 			Secure:   !httpInsecure,
@@ -315,7 +315,7 @@ func (w *Web) SignoutSession() {
 	http.SetCookie(w.w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    "",
-		Path:     backlink,
+		Path:     subdir,
 		HttpOnly: true,
 		Domain:   httpHost,
 		Secure:   !httpInsecure,
@@ -339,7 +339,7 @@ func (w *Web) SigninSession(admin bool, userID string) error {
 	http.SetCookie(w.w, &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    encoded,
-		Path:     backlink,
+		Path:     subdir,
 		HttpOnly: true,
 		Domain:   httpHost,
 		Secure:   !httpInsecure,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ if [ -z "${SUBSPACE_HTTP_HOST-}" ]; then
 fi
 # Optional environment variables.
 if [ -z "${SUBSPACE_BACKLINK-}" ]; then
-  export SUBSPACE_BACKLINK="/"
+  export SUBSPACE_BACKLINK=""
 fi
 
 if [ -z "${SUBSPACE_IPV4_POOL-}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ if [ -z "${SUBSPACE_HTTP_HOST-}" ]; then
   exit 1
 fi
 # Optional environment variables.
-if [ -z "${SUBSPACE_BACKLINK-}" ]; then
-  export SUBSPACE_BACKLINK=""
+if [ -z "${SUBSPACE_URL_SUBDIRECTORY-}" ]; then
+  export SUBSPACE_URL_SUBDIRECTORY=""
 fi
 
 if [ -z "${SUBSPACE_IPV4_POOL-}" ]; then
@@ -240,7 +240,7 @@ exec /usr/bin/subspace \
     "--http-host=${SUBSPACE_HTTP_HOST}" \
     "--http-addr=${SUBSPACE_HTTP_ADDR}" \
     "--http-insecure=${SUBSPACE_HTTP_INSECURE}" \
-    "--backlink=${SUBSPACE_BACKLINK}" \
+    "--subdir=${SUBSPACE_URL_SUBDIRECTORY}" \
     "--letsencrypt=${SUBSPACE_LETSENCRYPT}" \
     "--theme=${SUBSPACE_THEME}"
 RUNIT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,14 +46,19 @@ fi
 
 export DEBIAN_FRONTEND="noninteractive"
 
-if [ -z "${SUBSPACE_IPV4_GW-}" ]; then
+if [ -z "${SUBSPACE_IPV4_PREF-}" ]; then
   export SUBSPACE_IPV4_PREF=$(echo ${SUBSPACE_IPV4_POOL-} | cut -d '/' -f1 | sed 's/.0$/./g')
-  export SUBSPACE_IPV4_GW=$(echo ${SUBSPACE_IPV4_PREF-}1)
+fi
 
+if [ -z "${SUBSPACE_IPV6_PREF-}" ]; then
+  export SUBSPACE_IPV6_PREF=$(echo ${SUBSPACE_IPV6_POOL-} | cut -d '/' -f1 | sed 's/:0$/:/g')
+fi
+
+if [ -z "${SUBSPACE_IPV4_GW-}" ]; then
+  export SUBSPACE_IPV4_GW=$(echo ${SUBSPACE_IPV4_PREF-}1)
 fi
 
 if [ -z "${SUBSPACE_IPV6_GW-}" ]; then
-  export SUBSPACE_IPV6_PREF=$(echo ${SUBSPACE_IPV6_POOL-} | cut -d '/' -f1 | sed 's/:0$/:/g')
   export SUBSPACE_IPV6_GW=$(echo ${SUBSPACE_IPV6_PREF-}1)
 fi
 

--- a/web/templates/configure.html
+++ b/web/templates/configure.html
@@ -34,7 +34,7 @@
 
         <div class="ui hidden divider"></div>
 
-        <form class="ui huge form" action="{{$.Backlink}}/configure" method="POST" novalidate autocomplete="off">
+        <form class="ui huge form" action="{{$.SubDirectory}}/configure" method="POST" novalidate autocomplete="off">
             <div class="field">
                 <div class="ui small header">Email Address</div>
                 <input name="email" type="email" placeholder="Email Address" value="" autofocus>

--- a/web/templates/configure.html
+++ b/web/templates/configure.html
@@ -34,7 +34,7 @@
 
         <div class="ui hidden divider"></div>
 
-        <form class="ui huge form" action="/configure" method="POST" novalidate autocomplete="off">
+        <form class="ui huge form" action="{{.Backlink}}/configure" method="POST" novalidate autocomplete="off">
             <div class="field">
                 <div class="ui small header">Email Address</div>
                 <input name="email" type="email" placeholder="Email Address" value="" autofocus>

--- a/web/templates/configure.html
+++ b/web/templates/configure.html
@@ -34,7 +34,7 @@
 
         <div class="ui hidden divider"></div>
 
-        <form class="ui huge form" action="{{.Backlink}}/configure" method="POST" novalidate autocomplete="off">
+        <form class="ui huge form" action="{{$.Backlink}}/configure" method="POST" novalidate autocomplete="off">
             <div class="field">
                 <div class="ui small header">Email Address</div>
                 <input name="email" type="email" placeholder="Email Address" value="" autofocus>

--- a/web/templates/forgot.html
+++ b/web/templates/forgot.html
@@ -40,7 +40,7 @@
 
                 {{$email := $.Request.FormValue "email"}}
                 {{$secret := $.Request.FormValue "secret"}}
-                <form class="ui huge form" action="{{$.Backlink}}/forgot" method="POST" novalidate autocomplete="off">
+                <form class="ui huge form" action="{{$.SubDirectory}}/forgot" method="POST" novalidate autocomplete="off">
                     {{if and $email $secret}}
                         <input type="hidden" name="email" value="{{$email}}">
                         <input type="hidden" name="secret" value="{{$secret}}">

--- a/web/templates/forgot.html
+++ b/web/templates/forgot.html
@@ -40,7 +40,7 @@
 
                 {{$email := $.Request.FormValue "email"}}
                 {{$secret := $.Request.FormValue "secret"}}
-                <form class="ui huge form" action="/forgot" method="POST" novalidate autocomplete="off">
+                <form class="ui huge form" action="{{.Backlink}}/forgot" method="POST" novalidate autocomplete="off">
                     {{if and $email $secret}}
                         <input type="hidden" name="email" value="{{$email}}">
                         <input type="hidden" name="secret" value="{{$secret}}">

--- a/web/templates/forgot.html
+++ b/web/templates/forgot.html
@@ -40,7 +40,7 @@
 
                 {{$email := $.Request.FormValue "email"}}
                 {{$secret := $.Request.FormValue "secret"}}
-                <form class="ui huge form" action="{{.Backlink}}/forgot" method="POST" novalidate autocomplete="off">
+                <form class="ui huge form" action="{{$.Backlink}}/forgot" method="POST" novalidate autocomplete="off">
                     {{if and $email $secret}}
                         <input type="hidden" name="email" value="{{$email}}">
                         <input type="hidden" name="secret" value="{{$secret}}">

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -22,9 +22,9 @@
         <div class="borderless ui big {{$.SemanticTheme}} inverted menu">
             <div class="ui container">
                 {{if $.SubDirectory}}
-                    <a class="item" href="{{$.SubDirectory}}"><i class="home icon"></i></a>
+                    <a class="item" href="{{$.SubDirectory}}/"><i class="home icon"></i></a>
                 {{end}}
-                <a href="{{$.SubDirectory}}" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
+                <a href="{{$.SubDirectory}}/" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
                 {{if $.Admin}}
                     <a href="{{$.SubDirectory}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
                 {{end}}

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -5,17 +5,17 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
         <meta name="referrer" content="origin">
-        <link rel="icon" href="/static/favicon.png?v={{$.Version}}">
-        <link rel="apple-touch-icon" href="/static/favicon.png?v={{$.Version}}">
+        <link rel="icon" href="{{.Backlink}}/static/favicon.png?v={{$.Version}}">
+        <link rel="apple-touch-icon" href="{{.Backlink}}/static/favicon.png?v={{$.Version}}">
 
         <title>Subspace</title>
 
-        <link rel="stylesheet" type="text/css" href="/static/semantic/semantic.min.css?v={{$.Version}}">
-        <link rel="stylesheet" type="text/css" href="/static/style.css?v={{$.Version}}">
-        <link rel="stylesheet" type="text/css" href="/static/roboto.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{.Backlink}}/static/semantic/semantic.min.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{.Backlink}}/static/style.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{.Backlink}}/static/roboto.css?v={{$.Version}}">
 
-        <script src="/static/jquery.min.js?v={{$.Version}}"></script>
-        <script src="/static/semantic/semantic.min.js?v={{$.Version}}"></script>
+        <script src="{{.Backlink}}/static/jquery.min.js?v={{$.Version}}"></script>
+        <script src="{{.Backlink}}/static/semantic/semantic.min.js?v={{$.Version}}"></script>
     </head>
     <body>
 
@@ -24,9 +24,9 @@
                 {{if $.Backlink}}
                     <a class="item" href="{{.Backlink}}"><i class="home icon"></i></a>
                 {{end}}
-                <a href="/" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
+                <a href="{{.Backlink}}/" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
                 {{if $.Admin}}
-                    <a href="/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
+                    <a href="{{.Backlink}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
                 {{end}}
 
                 {{if eq $.Section "signin" "forgot"}}
@@ -40,8 +40,8 @@
                         {{end}}
                         <i class="dropdown icon"></i>
                         <div class="menu">
-                            <a href="/help" class="{{if eq $.Section "help"}}active{{end}} item"><i class="help icon"></i>Help</a>
-                            <a href="/signout" class="item confirm" data-prompt="Sign out?"><i class="sign out icon"></i>Sign out</a>
+                            <a href="{{.Backlink}}/help" class="{{if eq $.Section "help"}}active{{end}} item"><i class="help icon"></i>Help</a>
+                            <a href="{{.Backlink}}/signout" class="item confirm" data-prompt="Sign out?"><i class="sign out icon"></i>Sign out</a>
                         </div>
                     </div>
                 {{end}}

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -5,28 +5,28 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
         <meta name="referrer" content="origin">
-        <link rel="icon" href="{{.Backlink}}/static/favicon.png?v={{$.Version}}">
-        <link rel="apple-touch-icon" href="{{.Backlink}}/static/favicon.png?v={{$.Version}}">
+        <link rel="icon" href="{{$.Backlink}}/static/favicon.png?v={{$.Version}}">
+        <link rel="apple-touch-icon" href="{{$.Backlink}}/static/favicon.png?v={{$.Version}}">
 
         <title>Subspace</title>
 
-        <link rel="stylesheet" type="text/css" href="{{.Backlink}}/static/semantic/semantic.min.css?v={{$.Version}}">
-        <link rel="stylesheet" type="text/css" href="{{.Backlink}}/static/style.css?v={{$.Version}}">
-        <link rel="stylesheet" type="text/css" href="{{.Backlink}}/static/roboto.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{$.Backlink}}/static/semantic/semantic.min.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{$.Backlink}}/static/style.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{$.Backlink}}/static/roboto.css?v={{$.Version}}">
 
-        <script src="{{.Backlink}}/static/jquery.min.js?v={{$.Version}}"></script>
-        <script src="{{.Backlink}}/static/semantic/semantic.min.js?v={{$.Version}}"></script>
+        <script src="{{$.Backlink}}/static/jquery.min.js?v={{$.Version}}"></script>
+        <script src="{{$.Backlink}}/static/semantic/semantic.min.js?v={{$.Version}}"></script>
     </head>
     <body>
 
         <div class="borderless ui big {{$.SemanticTheme}} inverted menu">
             <div class="ui container">
                 {{if $.Backlink}}
-                    <a class="item" href="{{.Backlink}}"><i class="home icon"></i></a>
+                    <a class="item" href="{{$.Backlink}}"><i class="home icon"></i></a>
                 {{end}}
-                <a href="{{.Backlink}}/" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
+                <a href="{{$.Backlink}}/" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
                 {{if $.Admin}}
-                    <a href="{{.Backlink}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
+                    <a href="{{$.Backlink}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
                 {{end}}
 
                 {{if eq $.Section "signin" "forgot"}}
@@ -40,8 +40,8 @@
                         {{end}}
                         <i class="dropdown icon"></i>
                         <div class="menu">
-                            <a href="{{.Backlink}}/help" class="{{if eq $.Section "help"}}active{{end}} item"><i class="help icon"></i>Help</a>
-                            <a href="{{.Backlink}}/signout" class="item confirm" data-prompt="Sign out?"><i class="sign out icon"></i>Sign out</a>
+                            <a href="{{$.Backlink}}/help" class="{{if eq $.Section "help"}}active{{end}} item"><i class="help icon"></i>Help</a>
+                            <a href="{{$.Backlink}}/signout" class="item confirm" data-prompt="Sign out?"><i class="sign out icon"></i>Sign out</a>
                         </div>
                     </div>
                 {{end}}

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -5,28 +5,28 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
         <meta name="referrer" content="origin">
-        <link rel="icon" href="{{$.Backlink}}/static/favicon.png?v={{$.Version}}">
-        <link rel="apple-touch-icon" href="{{$.Backlink}}/static/favicon.png?v={{$.Version}}">
+        <link rel="icon" href="{{$.SubDirectory}}/static/favicon.png?v={{$.Version}}">
+        <link rel="apple-touch-icon" href="{{$.SubDirectory}}/static/favicon.png?v={{$.Version}}">
 
         <title>Subspace</title>
 
-        <link rel="stylesheet" type="text/css" href="{{$.Backlink}}/static/semantic/semantic.min.css?v={{$.Version}}">
-        <link rel="stylesheet" type="text/css" href="{{$.Backlink}}/static/style.css?v={{$.Version}}">
-        <link rel="stylesheet" type="text/css" href="{{$.Backlink}}/static/roboto.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{$.SubDirectory}}/static/semantic/semantic.min.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{$.SubDirectory}}/static/style.css?v={{$.Version}}">
+        <link rel="stylesheet" type="text/css" href="{{$.SubDirectory}}/static/roboto.css?v={{$.Version}}">
 
-        <script src="{{$.Backlink}}/static/jquery.min.js?v={{$.Version}}"></script>
-        <script src="{{$.Backlink}}/static/semantic/semantic.min.js?v={{$.Version}}"></script>
+        <script src="{{$.SubDirectory}}/static/jquery.min.js?v={{$.Version}}"></script>
+        <script src="{{$.SubDirectory}}/static/semantic/semantic.min.js?v={{$.Version}}"></script>
     </head>
     <body>
 
         <div class="borderless ui big {{$.SemanticTheme}} inverted menu">
             <div class="ui container">
-                {{if $.Backlink}}
-                    <a class="item" href="{{$.Backlink}}"><i class="home icon"></i></a>
+                {{if $.SubDirectory}}
+                    <a class="item" href="{{$.SubDirectory}}"><i class="home icon"></i></a>
                 {{end}}
-                <a href="{{$.Backlink}}" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
+                <a href="{{$.SubDirectory}}" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
                 {{if $.Admin}}
-                    <a href="{{$.Backlink}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
+                    <a href="{{$.SubDirectory}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
                 {{end}}
 
                 {{if eq $.Section "signin" "forgot"}}
@@ -40,8 +40,8 @@
                         {{end}}
                         <i class="dropdown icon"></i>
                         <div class="menu">
-                            <a href="{{$.Backlink}}/help" class="{{if eq $.Section "help"}}active{{end}} item"><i class="help icon"></i>Help</a>
-                            <a href="{{$.Backlink}}/signout" class="item confirm" data-prompt="Sign out?"><i class="sign out icon"></i>Sign out</a>
+                            <a href="{{$.SubDirectory}}/help" class="{{if eq $.Section "help"}}active{{end}} item"><i class="help icon"></i>Help</a>
+                            <a href="{{$.SubDirectory}}/signout" class="item confirm" data-prompt="Sign out?"><i class="sign out icon"></i>Sign out</a>
                         </div>
                     </div>
                 {{end}}

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -24,7 +24,7 @@
                 {{if $.Backlink}}
                     <a class="item" href="{{$.Backlink}}"><i class="home icon"></i></a>
                 {{end}}
-                <a href="{{$.Backlink}}/" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
+                <a href="{{$.Backlink}}" class="{{if eq $.Section "index"}}active{{end}} item">Subspace</a>
                 {{if $.Admin}}
                     <a href="{{$.Backlink}}/settings" class="{{if eq $.Section "settings"}}active{{end}} item">Settings</a>
                 {{end}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -23,7 +23,7 @@
                     {{if eq $error "addprofile"}}
                         Adding device failed
                     {{else if eq $error "deleteprofile"}}
-                        Adding device failed
+                        Deleting device failed
                     {{else if eq $error "profilename"}}
                         Device name is required
                     {{else}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
                     User deleted successfully
                 {{end}}
             </div>
-            <a class="close-link" href="{{$.Backlink}}"><i class="close icon"></i></a>
+            <a class="close-link" href="{{$.SubDirectory}}"><i class="close icon"></i></a>
         </div>
     {{end}}
     {{with $error := $.Request.FormValue "error"}}
@@ -30,7 +30,7 @@
                         {{$error}}
                     {{end}}
                 </div>
-                <a class="close-link" href="{{$.Backlink}}"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.SubDirectory}}"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>
@@ -47,7 +47,7 @@
                 <div class="ui hidden divider"></div>
             </div>
             <div class="column">
-                <form class="ui huge form" action="{{$.Backlink}}/profile/add" method="POST">
+                <form class="ui huge form" action="{{$.SubDirectory}}/profile/add" method="POST">
                     <div class="field">
                         <input name="name" type="text" value="{{$.Request.FormValue "name"}}" placeholder="Device name" autofocus>
                     </div>
@@ -104,7 +104,7 @@
                 <div class="ui three stackable cards">
                     {{range $n, $p := $.TargetProfiles}}
                         <div class="showcard card">
-                            <a href="{{$.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                            <a href="{{$.SubDirectory}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                             <div class="content">
                                 <div class="header">
                                     <i class="large grey
@@ -140,7 +140,7 @@
                                 </div>
                             </div>
                             <div class="extra content">
-                                <a href="{{$.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                                <a href="{{$.SubDirectory}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                             </div>
                         </div>
                     {{end}}
@@ -164,7 +164,7 @@
                 <div class="ui three stackable cards">
                     {{range $n, $p := $.Profiles}}
                         <div class="showcard card">
-                            <a href="{{$.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                            <a href="{{$.SubDirectory}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                             <div class="content">
                                 <div class="header">
                                     <i class="large grey
@@ -200,7 +200,7 @@
                                 </div>
                             </div>
                             <div class="extra content">
-                                <a href="{{$.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                                <a href="{{$.SubDirectory}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                             </div>
                         </div>
                     {{end}}
@@ -222,7 +222,7 @@
             <div class="ui three stackable cards">
                 {{range $n, $u := $.Users}}
                     <div class="showcard card">
-                        <a href="{{$.Backlink}}/user/delete/{{$u.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                        <a href="{{$.SubDirectory}}/user/delete/{{$u.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                         <div class="content">
                             <div class="header">
                                 <i class="large grey user icon"></i>
@@ -256,7 +256,7 @@
                             </div>
                         </div>
                         <div class="extra content">
-                            <a href="{{$.Backlink}}/user/edit/{{$u.ID}}" class="ui large basic fluid button">Manage user</a>
+                            <a href="{{$.SubDirectory}}/user/edit/{{$u.ID}}" class="ui large basic fluid button">Manage user</a>
                         </div>
                     </div>
                 {{end}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
                     User deleted successfully
                 {{end}}
             </div>
-            <a class="close-link" href="{{$.SubDirectory}}"><i class="close icon"></i></a>
+            <a class="close-link" href="{{$.SubDirectory}}/"><i class="close icon"></i></a>
         </div>
     {{end}}
     {{with $error := $.Request.FormValue "error"}}
@@ -30,7 +30,7 @@
                         {{$error}}
                     {{end}}
                 </div>
-                <a class="close-link" href="{{$.SubDirectory}}"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.SubDirectory}}/"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
                     User deleted successfully
                 {{end}}
             </div>
-            <a class="close-link" href="{{.Backlink}}/"><i class="close icon"></i></a>
+            <a class="close-link" href="{{$.Backlink}}/"><i class="close icon"></i></a>
         </div>
     {{end}}
     {{with $error := $.Request.FormValue "error"}}
@@ -30,7 +30,7 @@
                         {{$error}}
                     {{end}}
                 </div>
-                <a class="close-link" href="{{.Backlink}}/"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.Backlink}}/"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>
@@ -47,7 +47,7 @@
                 <div class="ui hidden divider"></div>
             </div>
             <div class="column">
-                <form class="ui huge form" action="{{.Backlink}}/profile/add" method="POST">
+                <form class="ui huge form" action="{{$.Backlink}}/profile/add" method="POST">
                     <div class="field">
                         <input name="name" type="text" value="{{$.Request.FormValue "name"}}" placeholder="Device name" autofocus>
                     </div>
@@ -104,7 +104,7 @@
                 <div class="ui three stackable cards">
                     {{range $n, $p := $.TargetProfiles}}
                         <div class="showcard card">
-                            <a href="{{.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                            <a href="{{$.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                             <div class="content">
                                 <div class="header">
                                     <i class="large grey
@@ -140,7 +140,7 @@
                                 </div>
                             </div>
                             <div class="extra content">
-                                <a href="{{.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                                <a href="{{$.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                             </div>
                         </div>
                     {{end}}
@@ -164,7 +164,7 @@
                 <div class="ui three stackable cards">
                     {{range $n, $p := $.Profiles}}
                         <div class="showcard card">
-                            <a href="{{.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                            <a href="{{$.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                             <div class="content">
                                 <div class="header">
                                     <i class="large grey
@@ -200,7 +200,7 @@
                                 </div>
                             </div>
                             <div class="extra content">
-                                <a href="{{.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                                <a href="{{$.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                             </div>
                         </div>
                     {{end}}
@@ -222,7 +222,7 @@
             <div class="ui three stackable cards">
                 {{range $n, $u := $.Users}}
                     <div class="showcard card">
-                        <a href="{{.Backlink}}/user/delete/{{$u.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                        <a href="{{$.Backlink}}/user/delete/{{$u.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                         <div class="content">
                             <div class="header">
                                 <i class="large grey user icon"></i>
@@ -256,7 +256,7 @@
                             </div>
                         </div>
                         <div class="extra content">
-                            <a href="{{.Backlink}}/user/edit/{{$u.ID}}" class="ui large basic fluid button">Manage user</a>
+                            <a href="{{$.Backlink}}/user/edit/{{$u.ID}}" class="ui large basic fluid button">Manage user</a>
                         </div>
                     </div>
                 {{end}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
                     User deleted successfully
                 {{end}}
             </div>
-            <a class="close-link" href="/"><i class="close icon"></i></a>
+            <a class="close-link" href="{{.Backlink}}/"><i class="close icon"></i></a>
         </div>
     {{end}}
     {{with $error := $.Request.FormValue "error"}}
@@ -30,7 +30,7 @@
                         {{$error}}
                     {{end}}
                 </div>
-                <a class="close-link" href="/"><i class="close icon"></i></a>
+                <a class="close-link" href="{{.Backlink}}/"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>
@@ -47,7 +47,7 @@
                 <div class="ui hidden divider"></div>
             </div>
             <div class="column">
-                <form class="ui huge form" action="/profile/add" method="POST">
+                <form class="ui huge form" action="{{.Backlink}}/profile/add" method="POST">
                     <div class="field">
                         <input name="name" type="text" value="{{$.Request.FormValue "name"}}" placeholder="Device name" autofocus>
                     </div>
@@ -104,7 +104,7 @@
                 <div class="ui three stackable cards">
                     {{range $n, $p := $.TargetProfiles}}
                         <div class="showcard card">
-                            <a href="/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                            <a href="{{.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                             <div class="content">
                                 <div class="header">
                                     <i class="large grey
@@ -140,7 +140,7 @@
                                 </div>
                             </div>
                             <div class="extra content">
-                                <a href="/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                                <a href="{{.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                             </div>
                         </div>
                     {{end}}
@@ -164,7 +164,7 @@
                 <div class="ui three stackable cards">
                     {{range $n, $p := $.Profiles}}
                         <div class="showcard card">
-                            <a href="/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                            <a href="{{.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                             <div class="content">
                                 <div class="header">
                                     <i class="large grey
@@ -200,7 +200,7 @@
                                 </div>
                             </div>
                             <div class="extra content">
-                                <a href="/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                                <a href="{{.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                             </div>
                         </div>
                     {{end}}
@@ -222,7 +222,7 @@
             <div class="ui three stackable cards">
                 {{range $n, $u := $.Users}}
                     <div class="showcard card">
-                        <a href="/user/delete/{{$u.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                        <a href="{{.Backlink}}/user/delete/{{$u.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                         <div class="content">
                             <div class="header">
                                 <i class="large grey user icon"></i>
@@ -256,7 +256,7 @@
                             </div>
                         </div>
                         <div class="extra content">
-                            <a href="/user/edit/{{$u.ID}}" class="ui large basic fluid button">Manage user</a>
+                            <a href="{{.Backlink}}/user/edit/{{$u.ID}}" class="ui large basic fluid button">Manage user</a>
                         </div>
                     </div>
                 {{end}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
                     User deleted successfully
                 {{end}}
             </div>
-            <a class="close-link" href="{{$.Backlink}}/"><i class="close icon"></i></a>
+            <a class="close-link" href="{{$.Backlink}}"><i class="close icon"></i></a>
         </div>
     {{end}}
     {{with $error := $.Request.FormValue "error"}}
@@ -30,7 +30,7 @@
                         {{$error}}
                     {{end}}
                 </div>
-                <a class="close-link" href="{{$.Backlink}}/"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.Backlink}}"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>

--- a/web/templates/profile/connect.html
+++ b/web/templates/profile/connect.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{$.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.Backlink}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     {{with $success := $.Request.FormValue "success"}}

--- a/web/templates/profile/connect.html
+++ b/web/templates/profile/connect.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{$.SubDirectory}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.SubDirectory}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     {{with $success := $.Request.FormValue "success"}}

--- a/web/templates/profile/connect.html
+++ b/web/templates/profile/connect.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     {{with $success := $.Request.FormValue "success"}}
@@ -14,7 +14,7 @@
                         {{$success}}
                     {{end}}
                 </div>
-                <a class="close-link" href="/profile/connect/{{$.Profile.ID}}"><i class="close icon"></i></a>
+                <a class="close-link" href="{{.Backlink}}/profile/connect/{{$.Profile.ID}}"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>
@@ -39,7 +39,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and import it into WireGuard
+                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and import it into WireGuard
                         </div>
                     </div>
                 </div>
@@ -59,7 +59,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> into your Downloads folder
+                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> into your Downloads folder
                         </div>
                     </div>
                 </div>
@@ -119,7 +119,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and open with WireGuard or use the QR code below
+                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and open with WireGuard or use the QR code below
                         </div>
                     </div>
                 </div>
@@ -142,7 +142,7 @@
             </div>
 
             <div class="ui hidden divider"></div>
-            <img class="ui centered medium image" src="/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
+            <img class="ui centered medium image" src="{{.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
 
         {{else if eq $.Profile.Platform "android"}}
             <div class="ui large header"><i class="android icon"></i> Android &mdash; Instructions</div>
@@ -159,7 +159,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> or use the QR code below
+                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> or use the QR code below
                         </div>
                     </div>
                 </div>
@@ -174,7 +174,7 @@
             </div>
 
             <div class="ui hidden divider"></div>
-            <img class="ui centered medium image" src="/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
+            <img class="ui centered medium image" src="{{.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
 
         {{else if eq $.Profile.Platform "linux"}}
             <div class="ui large header"><i class="linux icon"></i> Linux &mdash; Instructions</div>
@@ -191,7 +191,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
+                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
                         </div>
                     </div>
                 </div>
@@ -219,7 +219,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
+                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
                         </div>
                     </div>
                 </div>

--- a/web/templates/profile/connect.html
+++ b/web/templates/profile/connect.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{$.Backlink}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.SubDirectory}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     {{with $success := $.Request.FormValue "success"}}
@@ -14,7 +14,7 @@
                         {{$success}}
                     {{end}}
                 </div>
-                <a class="close-link" href="{{$.Backlink}}/profile/connect/{{$.Profile.ID}}"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.SubDirectory}}/profile/connect/{{$.Profile.ID}}"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>
@@ -39,7 +39,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and import it into WireGuard
+                            <a href="{{$.SubDirectory}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and import it into WireGuard
                         </div>
                     </div>
                 </div>
@@ -59,7 +59,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> into your Downloads folder
+                            <a href="{{$.SubDirectory}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> into your Downloads folder
                         </div>
                     </div>
                 </div>
@@ -119,7 +119,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and open with WireGuard or use the QR code below
+                            <a href="{{$.SubDirectory}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and open with WireGuard or use the QR code below
                         </div>
                     </div>
                 </div>
@@ -142,7 +142,7 @@
             </div>
 
             <div class="ui hidden divider"></div>
-            <img class="ui centered medium image" src="{{$.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
+            <img class="ui centered medium image" src="{{$.SubDirectory}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
 
         {{else if eq $.Profile.Platform "android"}}
             <div class="ui large header"><i class="android icon"></i> Android &mdash; Instructions</div>
@@ -159,7 +159,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> or use the QR code below
+                            <a href="{{$.SubDirectory}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> or use the QR code below
                         </div>
                     </div>
                 </div>
@@ -174,7 +174,7 @@
             </div>
 
             <div class="ui hidden divider"></div>
-            <img class="ui centered medium image" src="{{$.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
+            <img class="ui centered medium image" src="{{$.SubDirectory}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
 
         {{else if eq $.Profile.Platform "linux"}}
             <div class="ui large header"><i class="linux icon"></i> Linux &mdash; Instructions</div>
@@ -191,7 +191,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
+                            <a href="{{$.SubDirectory}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
                         </div>
                     </div>
                 </div>
@@ -219,7 +219,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
+                            <a href="{{$.SubDirectory}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
                         </div>
                     </div>
                 </div>

--- a/web/templates/profile/connect.html
+++ b/web/templates/profile/connect.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     {{with $success := $.Request.FormValue "success"}}
@@ -14,7 +14,7 @@
                         {{$success}}
                     {{end}}
                 </div>
-                <a class="close-link" href="{{.Backlink}}/profile/connect/{{$.Profile.ID}}"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.Backlink}}/profile/connect/{{$.Profile.ID}}"><i class="close icon"></i></a>
             </div>
         </div>
         <div class="ui hidden divider"></div>
@@ -39,7 +39,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and import it into WireGuard
+                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and import it into WireGuard
                         </div>
                     </div>
                 </div>
@@ -59,7 +59,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> into your Downloads folder
+                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> into your Downloads folder
                         </div>
                     </div>
                 </div>
@@ -119,7 +119,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and open with WireGuard or use the QR code below
+                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> and open with WireGuard or use the QR code below
                         </div>
                     </div>
                 </div>
@@ -142,7 +142,7 @@
             </div>
 
             <div class="ui hidden divider"></div>
-            <img class="ui centered medium image" src="{{.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
+            <img class="ui centered medium image" src="{{$.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
 
         {{else if eq $.Profile.Platform "android"}}
             <div class="ui large header"><i class="android icon"></i> Android &mdash; Instructions</div>
@@ -159,7 +159,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> or use the QR code below
+                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a> or use the QR code below
                         </div>
                     </div>
                 </div>
@@ -174,7 +174,7 @@
             </div>
 
             <div class="ui hidden divider"></div>
-            <img class="ui centered medium image" src="{{.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
+            <img class="ui centered medium image" src="{{$.Backlink}}/profile/qrconfig/wireguard/{{$.Profile.ID}}" alt="qr-code could not be displayed">
 
         {{else if eq $.Profile.Platform "linux"}}
             <div class="ui large header"><i class="linux icon"></i> Linux &mdash; Instructions</div>
@@ -191,7 +191,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
+                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
                         </div>
                     </div>
                 </div>
@@ -219,7 +219,7 @@
                     <i class="right triangle icon"></i>
                     <div class="content">
                         <div class="description">
-                            <a href="{{.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
+                            <a href="{{$.Backlink}}/profile/config/wireguard/{{$.Profile.ID}}">Download your WireGuard config</a>
                         </div>
                     </div>
                 </div>

--- a/web/templates/profile/delete.html
+++ b/web/templates/profile/delete.html
@@ -15,7 +15,7 @@
                 <form action="{{$.SubDirectory}}/profile/delete" method="POST">
                     <input type="hidden" name="profile" value="{{$.Profile.ID}}">
                     <div class="two ui buttons">
-                        <a href="{{$.SubDirectory}}" class="ui large button">Cancel</a>
+                        <a href="{{$.SubDirectory}}/" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete device?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/profile/delete.html
+++ b/web/templates/profile/delete.html
@@ -15,7 +15,7 @@
                 <form action="{{$.Backlink}}/profile/delete" method="POST">
                     <input type="hidden" name="profile" value="{{$.Profile.ID}}">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}/" class="ui large button">Cancel</a>
+                        <a href="{{$.Backlink}}" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete device?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/profile/delete.html
+++ b/web/templates/profile/delete.html
@@ -12,10 +12,10 @@
                 </div>
                 <div class="ui hidden divider"></div>
 
-                <form action="{{$.Backlink}}/profile/delete" method="POST">
+                <form action="{{$.SubDirectory}}/profile/delete" method="POST">
                     <input type="hidden" name="profile" value="{{$.Profile.ID}}">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}" class="ui large button">Cancel</a>
+                        <a href="{{$.SubDirectory}}" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete device?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/profile/delete.html
+++ b/web/templates/profile/delete.html
@@ -12,10 +12,10 @@
                 </div>
                 <div class="ui hidden divider"></div>
 
-                <form action="/profile/delete" method="POST">
+                <form action="{{.Backlink}}/profile/delete" method="POST">
                     <input type="hidden" name="profile" value="{{$.Profile.ID}}">
                     <div class="two ui buttons">
-                        <a href="/" class="ui large button">Cancel</a>
+                        <a href="{{.Backlink}}/" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete device?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/profile/delete.html
+++ b/web/templates/profile/delete.html
@@ -12,10 +12,10 @@
                 </div>
                 <div class="ui hidden divider"></div>
 
-                <form action="{{.Backlink}}/profile/delete" method="POST">
+                <form action="{{$.Backlink}}/profile/delete" method="POST">
                     <input type="hidden" name="profile" value="{{$.Profile.ID}}">
                     <div class="two ui buttons">
-                        <a href="{{.Backlink}}/" class="ui large button">Cancel</a>
+                        <a href="{{$.Backlink}}/" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete device?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -70,7 +70,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
+                        <a href="{{$.SubDirectory}}/" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -97,7 +97,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
+                        <a href="{{$.SubDirectory}}/" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
+                            <a href="{{$.SubDirectory}}/" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge red button">Remove Totp</button>
                         </div>
                     </div>
@@ -137,7 +137,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
+                            <a href="{{$.SubDirectory}}/" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                         </div>
                     </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -17,7 +17,7 @@
                         TOTP reset for default user, please reconfigure for improved security.
                     {{end}}
                 </div>
-                <a class="close-link" href="/settings"><i class="close icon"></i></a>
+                <a class="close-link" href="{{.Backlink}}/settings"><i class="close icon"></i></a>
             </div>
             <div class="ui hidden divider"></div>
         {{end}}
@@ -39,7 +39,7 @@
             <div class="ui hidden divider"></div>
         {{end}}
 
-        <form class="ui huge form" action="/settings" method="POST" novalidate autocomplete="off">
+        <form class="ui huge form" action="{{.Backlink}}/settings" method="POST" novalidate autocomplete="off">
             <div class="ui {{$.SemanticTheme}} dividing header">Single Sign-On (SAML)</div>
             <div class="ui message">
                 <i class="info circle grey icon"></i>
@@ -70,7 +70,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="/" class="ui huge button">Cancel</a>
+                        <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -97,7 +97,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="/" class="ui huge button">Cancel</a>
+                        <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="/" class="ui huge button">Cancel</a>
+                            <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge red button">Remove Totp</button>
                         </div>
                     </div>
@@ -125,7 +125,7 @@
                 <div class="ui hidden divider"></div>
                 <div class="ui centered segment">
                     <div class="ui bottom attached label">Secret: {{$.TempTotpKey.Secret}}</div>
-                    <img class="ui centered image" src="/totp/image" alt="TOTP qr-code could not be displayed">
+                    <img class="ui centered image" src="{{.Backlink}}/totp/image" alt="TOTP qr-code could not be displayed">
                 </div>
                 <div class="ui hidden divider"></div>
                 <div class="field">
@@ -137,7 +137,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="/" class="ui huge button">Cancel</a>
+                            <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                         </div>
                     </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -55,11 +55,11 @@
 
             <div class="field">
                 <div class="ui small header">Your ACS URL</div>
-                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}/saml/acs" readonly>
+                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}{{$.Backlink}}/saml/acs" readonly>
             </div>
             <div class="field">
                 <div class="ui small header">Your Entity ID</div>
-                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}/saml/metadata" readonly>
+                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}{{$.Backlink}}/saml/metadata" readonly>
             </div>
             <div class="field">
                 <div class="ui small header">IDP Metadata</div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -17,7 +17,7 @@
                         TOTP reset for default user, please reconfigure for improved security.
                     {{end}}
                 </div>
-                <a class="close-link" href="{{.Backlink}}/settings"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.Backlink}}/settings"><i class="close icon"></i></a>
             </div>
             <div class="ui hidden divider"></div>
         {{end}}
@@ -39,7 +39,7 @@
             <div class="ui hidden divider"></div>
         {{end}}
 
-        <form class="ui huge form" action="{{.Backlink}}/settings" method="POST" novalidate autocomplete="off">
+        <form class="ui huge form" action="{{$.Backlink}}/settings" method="POST" novalidate autocomplete="off">
             <div class="ui {{$.SemanticTheme}} dividing header">Single Sign-On (SAML)</div>
             <div class="ui message">
                 <i class="info circle grey icon"></i>
@@ -70,7 +70,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
+                        <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -97,7 +97,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
+                        <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
+                            <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge red button">Remove Totp</button>
                         </div>
                     </div>
@@ -125,7 +125,7 @@
                 <div class="ui hidden divider"></div>
                 <div class="ui centered segment">
                     <div class="ui bottom attached label">Secret: {{$.TempTotpKey.Secret}}</div>
-                    <img class="ui centered image" src="{{.Backlink}}/totp/image" alt="TOTP qr-code could not be displayed">
+                    <img class="ui centered image" src="{{$.Backlink}}/totp/image" alt="TOTP qr-code could not be displayed">
                 </div>
                 <div class="ui hidden divider"></div>
                 <div class="field">
@@ -137,7 +137,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{.Backlink}}/" class="ui huge button">Cancel</a>
+                            <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                         </div>
                     </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -17,7 +17,7 @@
                         TOTP reset for default user, please reconfigure for improved security.
                     {{end}}
                 </div>
-                <a class="close-link" href="{{$.Backlink}}/settings"><i class="close icon"></i></a>
+                <a class="close-link" href="{{$.SubDirectory}}/settings"><i class="close icon"></i></a>
             </div>
             <div class="ui hidden divider"></div>
         {{end}}
@@ -39,7 +39,7 @@
             <div class="ui hidden divider"></div>
         {{end}}
 
-        <form class="ui huge form" action="{{$.Backlink}}/settings" method="POST" novalidate autocomplete="off">
+        <form class="ui huge form" action="{{$.SubDirectory}}/settings" method="POST" novalidate autocomplete="off">
             <div class="ui {{$.SemanticTheme}} dividing header">Single Sign-On (SAML)</div>
             <div class="ui message">
                 <i class="info circle grey icon"></i>
@@ -55,11 +55,11 @@
 
             <div class="field">
                 <div class="ui small header">Your ACS URL</div>
-                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}{{$.Backlink}}/saml/acs" readonly>
+                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}{{$.SubDirectory}}/saml/acs" readonly>
             </div>
             <div class="field">
                 <div class="ui small header">Your Entity ID</div>
-                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}{{$.Backlink}}/saml/metadata" readonly>
+                <input class="readonly-input" type="text" value="https://{{$.Request.Host}}{{$.SubDirectory}}/saml/metadata" readonly>
             </div>
             <div class="field">
                 <div class="ui small header">IDP Metadata</div>
@@ -70,7 +70,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
+                        <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -97,7 +97,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
+                        <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
+                            <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge red button">Remove Totp</button>
                         </div>
                     </div>
@@ -125,7 +125,7 @@
                 <div class="ui hidden divider"></div>
                 <div class="ui centered segment">
                     <div class="ui bottom attached label">Secret: {{$.TempTotpKey.Secret}}</div>
-                    <img class="ui centered image" src="{{$.Backlink}}/totp/image" alt="TOTP qr-code could not be displayed">
+                    <img class="ui centered image" src="{{$.SubDirectory}}/totp/image" alt="TOTP qr-code could not be displayed">
                 </div>
                 <div class="ui hidden divider"></div>
                 <div class="field">
@@ -137,7 +137,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
+                            <a href="{{$.SubDirectory}}" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                         </div>
                     </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -70,7 +70,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
+                        <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -97,7 +97,7 @@
                 <div class="field mobile hidden">&nbsp;</div>
                 <div class="field">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
+                        <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
                         <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
+                            <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge red button">Remove Totp</button>
                         </div>
                     </div>
@@ -137,7 +137,7 @@
                     <div class="field mobile hidden">&nbsp;</div>
                     <div class="field">
                         <div class="two ui buttons">
-                            <a href="{{$.Backlink}}/" class="ui huge button">Cancel</a>
+                            <a href="{{$.Backlink}}" class="ui huge button">Cancel</a>
                             <button type="submit" class="ui huge {{$.SemanticTheme}} button">Save</button>
                         </div>
                     </div>

--- a/web/templates/signin.html
+++ b/web/templates/signin.html
@@ -25,7 +25,7 @@
                 <div class="ui hidden divider"></div>
 
                 {{$ssoprovider := ssoprovider}}
-                <a href="{{.Backlink}}/sso" class="ui huge fluid blue button">{{if eq $ssoprovider "Google"}}<i class="google icon"></i>{{end}}Sign in with {{$ssoprovider}}</a>
+                <a href="{{$.Backlink}}/sso" class="ui huge fluid blue button">{{if eq $ssoprovider "Google"}}<i class="google icon"></i>{{end}}Sign in with {{$ssoprovider}}</a>
 
                 <div class="ui hidden divider"></div>
                 <div class="ui hidden divider"></div>
@@ -33,7 +33,7 @@
 
             <div class="ui large center aligned dividing header">Admin Sign In</div>
             <div class="ui hidden divider"></div>
-            <form class="ui huge form" action="{{.Backlink}}/signin" method="POST">
+            <form class="ui huge form" action="{{$.Backlink}}/signin" method="POST">
                 <div class="field">
                     <div class="ui left icon input">
                         <i class="mail icon"></i>
@@ -59,7 +59,7 @@
                 <div class="center-aligned field">
                     <button type="submit" class="ui huge fluid {{$.SemanticTheme}} button">Sign in</button>
                     <div class="ui hidden divider"></div>
-                    <a href="{{.Backlink}}/forgot">Forgot password?</a>
+                    <a href="{{$.Backlink}}/forgot">Forgot password?</a>
                 </div>
 
             </form>

--- a/web/templates/signin.html
+++ b/web/templates/signin.html
@@ -25,7 +25,7 @@
                 <div class="ui hidden divider"></div>
 
                 {{$ssoprovider := ssoprovider}}
-                <a href="/sso" class="ui huge fluid blue button">{{if eq $ssoprovider "Google"}}<i class="google icon"></i>{{end}}Sign in with {{$ssoprovider}}</a>
+                <a href="{{.Backlink}}/sso" class="ui huge fluid blue button">{{if eq $ssoprovider "Google"}}<i class="google icon"></i>{{end}}Sign in with {{$ssoprovider}}</a>
 
                 <div class="ui hidden divider"></div>
                 <div class="ui hidden divider"></div>
@@ -33,7 +33,7 @@
 
             <div class="ui large center aligned dividing header">Admin Sign In</div>
             <div class="ui hidden divider"></div>
-            <form class="ui huge form" action="/signin" method="POST">
+            <form class="ui huge form" action="{{.Backlink}}/signin" method="POST">
                 <div class="field">
                     <div class="ui left icon input">
                         <i class="mail icon"></i>
@@ -59,7 +59,7 @@
                 <div class="center-aligned field">
                     <button type="submit" class="ui huge fluid {{$.SemanticTheme}} button">Sign in</button>
                     <div class="ui hidden divider"></div>
-                    <a href="/forgot">Forgot password?</a>
+                    <a href="{{.Backlink}}/forgot">Forgot password?</a>
                 </div>
 
             </form>

--- a/web/templates/signin.html
+++ b/web/templates/signin.html
@@ -25,7 +25,7 @@
                 <div class="ui hidden divider"></div>
 
                 {{$ssoprovider := ssoprovider}}
-                <a href="{{$.Backlink}}/sso" class="ui huge fluid blue button">{{if eq $ssoprovider "Google"}}<i class="google icon"></i>{{end}}Sign in with {{$ssoprovider}}</a>
+                <a href="{{$.SubDirectory}}/sso" class="ui huge fluid blue button">{{if eq $ssoprovider "Google"}}<i class="google icon"></i>{{end}}Sign in with {{$ssoprovider}}</a>
 
                 <div class="ui hidden divider"></div>
                 <div class="ui hidden divider"></div>
@@ -33,7 +33,7 @@
 
             <div class="ui large center aligned dividing header">Admin Sign In</div>
             <div class="ui hidden divider"></div>
-            <form class="ui huge form" action="{{$.Backlink}}/signin" method="POST">
+            <form class="ui huge form" action="{{$.SubDirectory}}/signin" method="POST">
                 <div class="field">
                     <div class="ui left icon input">
                         <i class="mail icon"></i>
@@ -59,7 +59,7 @@
                 <div class="center-aligned field">
                     <button type="submit" class="ui huge fluid {{$.SemanticTheme}} button">Sign in</button>
                     <div class="ui hidden divider"></div>
-                    <a href="{{$.Backlink}}/forgot">Forgot password?</a>
+                    <a href="{{$.SubDirectory}}/forgot">Forgot password?</a>
                 </div>
 
             </form>

--- a/web/templates/user/delete.html
+++ b/web/templates/user/delete.html
@@ -12,10 +12,10 @@
                 </div>
                 <div class="ui hidden divider"></div>
 
-                <form action="/user/delete" method="POST">
+                <form action="{{.Backlink}}/user/delete" method="POST">
                     <input type="hidden" name="user" value="{{$.TargetUser.ID}}">
                     <div class="two ui buttons">
-                        <a href="/user/edit/{{$.TargetUser.ID}}" class="ui large button">Cancel</a>
+                        <a href="{{.Backlink}}/user/edit/{{$.TargetUser.ID}}" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete user?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/user/delete.html
+++ b/web/templates/user/delete.html
@@ -12,10 +12,10 @@
                 </div>
                 <div class="ui hidden divider"></div>
 
-                <form action="{{.Backlink}}/user/delete" method="POST">
+                <form action="{{$.Backlink}}/user/delete" method="POST">
                     <input type="hidden" name="user" value="{{$.TargetUser.ID}}">
                     <div class="two ui buttons">
-                        <a href="{{.Backlink}}/user/edit/{{$.TargetUser.ID}}" class="ui large button">Cancel</a>
+                        <a href="{{$.Backlink}}/user/edit/{{$.TargetUser.ID}}" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete user?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/user/delete.html
+++ b/web/templates/user/delete.html
@@ -12,10 +12,10 @@
                 </div>
                 <div class="ui hidden divider"></div>
 
-                <form action="{{$.Backlink}}/user/delete" method="POST">
+                <form action="{{$.SubDirectory}}/user/delete" method="POST">
                     <input type="hidden" name="user" value="{{$.TargetUser.ID}}">
                     <div class="two ui buttons">
-                        <a href="{{$.Backlink}}/user/edit/{{$.TargetUser.ID}}" class="ui large button">Cancel</a>
+                        <a href="{{$.SubDirectory}}/user/edit/{{$.TargetUser.ID}}" class="ui large button">Cancel</a>
                         <button type="submit" class="ui large {{$.SemanticTheme}} button confirm" data-prompt="Delete user?">Delete</button>
                     </div>
                 </form>

--- a/web/templates/user/edit.html
+++ b/web/templates/user/edit.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     <div class="ui padded segment">
@@ -14,7 +14,7 @@
             <div class="ui three stackable cards">
                 {{range $n, $p := $.Profiles}}
                     <div class="showcard card">
-                        <a href="{{.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                        <a href="{{$.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                         <div class="content">
                             <div class="header">
                                 <i class="large grey
@@ -50,7 +50,7 @@
                             </div>
                         </div>
                         <div class="extra content">
-                            <a href="{{.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                            <a href="{{$.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                         </div>
                     </div>
                 {{end}}
@@ -66,7 +66,7 @@
 
         <div class="ui equal width grid">
             <div class="column">
-                <form class="ui large form" method="POST" action="{{.Backlink}}/user/edit">
+                <form class="ui large form" method="POST" action="{{$.Backlink}}/user/edit">
                     <input type="hidden" name="user" value="{{$.TargetUser.ID}}">
                     <div class="equal width fields">
                         <div class="field left-aligned">
@@ -77,7 +77,7 @@
                             {{end}}
                         </div>
                         <div class="field right-aligned">
-                            <a href="{{.Backlink}}/user/delete/{{$.TargetUser.ID}}" class="ui large basic button">Delete</a>
+                            <a href="{{$.Backlink}}/user/delete/{{$.TargetUser.ID}}" class="ui large basic button">Delete</a>
                         </div>
                     </div>
                 </form>

--- a/web/templates/user/edit.html
+++ b/web/templates/user/edit.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{$.SubDirectory}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.SubDirectory}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     <div class="ui padded segment">

--- a/web/templates/user/edit.html
+++ b/web/templates/user/edit.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{$.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.Backlink}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     <div class="ui padded segment">

--- a/web/templates/user/edit.html
+++ b/web/templates/user/edit.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{.Backlink}}/" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     <div class="ui padded segment">
@@ -14,7 +14,7 @@
             <div class="ui three stackable cards">
                 {{range $n, $p := $.Profiles}}
                     <div class="showcard card">
-                        <a href="/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                        <a href="{{.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                         <div class="content">
                             <div class="header">
                                 <i class="large grey
@@ -50,7 +50,7 @@
                             </div>
                         </div>
                         <div class="extra content">
-                            <a href="/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                            <a href="{{.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                         </div>
                     </div>
                 {{end}}
@@ -66,7 +66,7 @@
 
         <div class="ui equal width grid">
             <div class="column">
-                <form class="ui large form" method="POST" action="/user/edit">
+                <form class="ui large form" method="POST" action="{{.Backlink}}/user/edit">
                     <input type="hidden" name="user" value="{{$.TargetUser.ID}}">
                     <div class="equal width fields">
                         <div class="field left-aligned">
@@ -77,7 +77,7 @@
                             {{end}}
                         </div>
                         <div class="field right-aligned">
-                            <a href="/user/delete/{{$.TargetUser.ID}}" class="ui large basic button">Delete</a>
+                            <a href="{{.Backlink}}/user/delete/{{$.TargetUser.ID}}" class="ui large basic button">Delete</a>
                         </div>
                     </div>
                 </form>

--- a/web/templates/user/edit.html
+++ b/web/templates/user/edit.html
@@ -1,7 +1,7 @@
 {{template "header.html" .}}
 
 <div class="ui container">
-    <a href="{{$.Backlink}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
+    <a href="{{$.SubDirectory}}" class="ui large basic button"><i class="long arrow alternate left icon"></i>Back</a>
     <div class="ui hidden divider"></div>
 
     <div class="ui padded segment">
@@ -14,7 +14,7 @@
             <div class="ui three stackable cards">
                 {{range $n, $p := $.Profiles}}
                     <div class="showcard card">
-                        <a href="{{$.Backlink}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
+                        <a href="{{$.SubDirectory}}/profile/delete/{{$p.ID}}" class="ui right corner label "><i class="trash alternate icon"></i></a>
                         <div class="content">
                             <div class="header">
                                 <i class="large grey
@@ -50,7 +50,7 @@
                             </div>
                         </div>
                         <div class="extra content">
-                            <a href="{{$.Backlink}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
+                            <a href="{{$.SubDirectory}}/profile/connect/{{$p.ID}}" class="ui large basic fluid button">Connect device</a>
                         </div>
                     </div>
                 {{end}}
@@ -66,7 +66,7 @@
 
         <div class="ui equal width grid">
             <div class="column">
-                <form class="ui large form" method="POST" action="{{$.Backlink}}/user/edit">
+                <form class="ui large form" method="POST" action="{{$.SubDirectory}}/user/edit">
                     <input type="hidden" name="user" value="{{$.TargetUser.ID}}">
                     <div class="equal width fields">
                         <div class="field left-aligned">
@@ -77,7 +77,7 @@
                             {{end}}
                         </div>
                         <div class="field right-aligned">
-                            <a href="{{$.Backlink}}/user/delete/{{$.TargetUser.ID}}" class="ui large basic button">Delete</a>
+                            <a href="{{$.SubDirectory}}/user/delete/{{$.TargetUser.ID}}" class="ui large basic button">Delete</a>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
cc: @subspacecommunity/subspace-maintainers
resolves: #195 #158 

## Background
- For URL and absolute path issues, see #195.
- This PR also implemented a fix on WireGuard subnetting issue that described in #158.
- This PR also implemented a fix on profile deletion, which originally will result in a 404 error.

## Changes
* Prepended all template links with a subdirectory URL path
* Reworded "backlink" to either "subdir"/"SubDirectory"/"URL_SUBDIRECTORY" accordingly
* Fixed WireGuard configuration by utilizing the subnet provided by user
* Fixed Subspace peer deletion redirection to a 404 error page

## Testing
The changes have been baked into a Docker image locally, it is up and running healthily with a WireGuard server installed on the host. All pages and functions are tested, **except SAML and IDP related features/pages/functionalities**.