### PR TITLE
Possibility to set client config filename to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ $ subspace --http-host subspace.example.com
 | `SUBSPACE_THEME`            | `green`             | The theme to use, please refer to [semantic-ui](https://semantic-ui.com/usage/theming.html) for accepted colors                                      |
 | `SUBSPACE_BACKLINK`         | `/`                 | The page to set the home button to                                                                                                                   |
 | `SUBSPACE_DISABLE_DNS`      | `false`             | Whether to disable DNS so the client uses their own configured DNS server(s). Consider disabling DNS server, if supporting international VPN clients |
+| `SUBSPACE_CONFIG_FILENAME`  | `wg0.conf`          | Client config filename to download                                                                                                                   |
 
 ### Run as a Docker container
 

--- a/cmd/subspace/config.go
+++ b/cmd/subspace/config.go
@@ -55,10 +55,6 @@ func (p Profile) WireGuardConfigPath() string {
 	return fmt.Sprintf("%s/wireguard/clients/%s.conf", datadir, p.ID)
 }
 
-func (p Profile) WireGuardConfigName() string {
-	return "wg0.conf"
-}
-
 type Info struct {
 	Email      string `json:"email"`
 	Password   []byte `json:"password"`
@@ -102,7 +98,7 @@ func NewConfig(filename string) (*Config, error) {
 	// Create new config with defaults
 	if os.IsNotExist(err) {
 		c.Info = &Info{
-			Email: "null",
+			Email:    "null",
 			HashKey:  RandomString(32),
 			BlockKey: RandomString(32),
 		}

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -109,7 +109,7 @@ func wireguardConfigHandler(w *Web) {
 		return
 	}
 
-	w.w.Header().Set("Content-Disposition", "attachment; filename="+profile.WireGuardConfigName())
+	w.w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", getEnv("SUBSPACE_CONFIG_FILENAME", "wg0.conf")))
 	w.w.Header().Set("Content-Type", "application/x-wireguard-profile")
 	w.w.Header().Set("Content-Length", fmt.Sprintf("%d", len(b)))
 	if _, err := w.w.Write(b); err != nil {


### PR DESCRIPTION
to: @subspacecommunity/subspace-maintainers
resolves: https://github.com/subspacecommunity/subspace/issues/118

## Background

There is no way to change config filename, which clients download from UI

### Changes

* Add possibility to set client config filename to download


## Testing

1. Login to the subspace
2. Add new device
3. Download config for the newly created device
4. Download config for the previously created device (before upgrade)


