### PR TITLE
dnsmasq fix 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -211,7 +211,7 @@ DNSMASQ
     mkdir -p /etc/service/dnsmasq
     cat <<RUNIT >/etc/service/dnsmasq/run
 #!/bin/sh
-exec /usr/sbin/dnsmasq --no-daemon
+exec /usr/sbin/dnsmasq --keep-in-foreground
 RUNIT
     chmod +x /etc/service/dnsmasq/run
 


### PR DESCRIPTION
to: @subspacecommunity/subspace-maintainers
related to:
resolves: https://github.com/subspacecommunity/subspace/issues/199

## Background

Clients were reporting DNS timeouts every few hours with subspace, with the only resolution being to either restart the container or turn off DNS. Upon investigating, it seems subspace is using the wrong flag for dnsmasq, passing a debug flag instead of the approved production flag. This switches that. See: https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html

```     Debug mode: don't fork to the background, don't write a pid file, don't change user id, generate a complete cache dump on receipt on SIGUSR1, log to stderr as well as syslog, don't fork new processes to handle TCP queries. Note that this option is for use in debugging only, to stop dnsmasq daemonising in production, use --keep-in-foreground.  ```

### Changes

* changes the flag from --no-daemon to -keep-in-foreground


## Testing

```
root      4030  0.0  0.0    784     4 ?        Ss   11:49   0:00          \_ runsv dnsmasq
nfsnobo+  4036  0.0  0.0   2188  1692 ?        S    11:49   0:00          |   \_ /usr/sbin/dnsmasq --keep-in-foreground
$ docker-compose ps
  Name                Command               State   Ports
---------------------------------------------------------
subspace   /usr/local/bin/entrypoint. ...   Up
CONTAINER ID   IMAGE                                     COMMAND                  CREATED       STATUS          PORTS     NAMES
ad67ccc1ba2c   subspacecommunity/subspace:amd64-v1.5.0   "/usr/local/bin/entr…"   4 weeks ago   Up 3 weeks             subspace
```

Currently running a prolonged test with a few dozen users and so far everything looks good 



