### PR TITLE
Custom client nameservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ $ subspace --http-host subspace.example.com
 | `SUBSPACE_THEME`            | `green`             | The theme to use, please refer to [semantic-ui](https://semantic-ui.com/usage/theming.html) for accepted colors                                      |
 | `SUBSPACE_BACKLINK`         | `/`                 | The page to set the home button to                                                                                                                   |
 | `SUBSPACE_DISABLE_DNS`      | `false`             | Whether to disable DNS so the client uses their own configured DNS server(s). Consider disabling DNS server, if supporting international VPN clients |
+| `SUBSPACE_CLIENT_NAMESERVERS` | `false` | List of custom DNS servers to include in the user config |
 | `SUBSPACE_PERSISTENT_KEEPALIVE`      | `0`             | Whether PersistentKeepalive should be enabled for clients (seconds) |
 
 ### Run as a Docker container
@@ -182,6 +183,8 @@ Make sure to change the `--env SUBSPACE_HTTP_HOST` to your publicly accessible d
 If you want to run the vpn on a different domain as the http host you can set `--env SUBSPACE_ENDPOINT_HOST`
 
 Use `--env SUBSPACE_DISABLE_DNS=1` to make subspace generate WireGuard configs without the `DNS` option, preserving the user's DNS servers.
+
+As an alternative, you can pass a list of preferred DNS servers in the `SUBSPACE_CLIENT_NAMESERVERS` variable (e.g. `--env SUBSPACE_CLIENT_NAMESERVERS="8.8.8.8,1.1.1.1"`).
 
 ```bash
 

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -487,12 +487,10 @@ WGPEER
 cat <<WGCLIENT >clients/{{$.Profile.ID}}.conf
 [Interface]
 PrivateKey = ${wg_private_key}
-{{- if not .DisableDNS }}
 {{- if .ClientNameServers }}
 DNS = {{.ClientNameServers}}
-{{- else }}
+{{- else if not .DisableDNS }}
 DNS = {{if .Ipv4Enabled}}{{$.IPv4Gw}}{{end}}{{if .Ipv6Enabled}}{{if .Ipv4Enabled}},{{end}}{{$.IPv6Gw}}{{end}}
-{{- end }}
 {{- end }}
 Address = {{if .Ipv4Enabled}}{{$.IPv4Pref}}{{$.Profile.Number}}/{{$.IPv4Cidr}}{{end}}{{if .Ipv6Enabled}}{{if .Ipv4Enabled}},{{end}}{{$.IPv6Pref}}{{$.Profile.Number}}/{{$.IPv6Cidr}}{{end}}
 


### PR DESCRIPTION
to: @subspacecommunity/subspace-maintainers

## Background

If `SUBSPACE_DISABLE_DNS` is set to `true`, but a client uses nameservers in his local subnet (e.g. his IP address is `10.0.0.2`, netmask `/24`, home gateway and caching DNS server - `10.0.0.1`), he won't be able to reach it. It can be solved partially by adding all private subnets to an exclusion list:

```
SUBSPACE_ALLOWED_IPS="::/0, 1.0.0.0/8, 2.0.0.0/8, 3.0.0.0/8, 4.0.0.0/6, 8.0.0.0/7, 11.0.0.0/8, 12.0.0.0/6, 16.0.0.0/4, 32.0.0.0/3, 64.0.0.0/2, 128.0.0.0/3, 160.0.0.0/5, 168.0.0.0/6, 172.0.0.0/12, 172.32.0.0/11, 172.64.0.0/10, 172.128.0.0/9, 173.0.0.0/8, 174.0.0.0/7, 176.0.0.0/4, 192.0.0.0/9, 192.128.0.0/11, 192.160.0.0/13, 192.169.0.0/16, 192.170.0.0/15, 192.172.0.0/14, 192.176.0.0/12, 192.192.0.0/10, 193.0.0.0/8, 194.0.0.0/7, 196.0.0.0/6, 200.0.0.0/5, 208.0.0.0/4"
```

but in some cases that local DNS server still will be unavailable (e.g. if kill-switch mode is enabled).

### Changes

Now, if variable `SUBSPACE_CLIENT_NAMESERVERS` is set and contain a valid comma-separated list of DNS servers, this list will be included in a client config as is.

Example:

```
--env SUBSPACE_CLIENT_NAMESERVERS="8.8.8.8,1.1.1.1"
```
